### PR TITLE
Add canonical tag for improved SEO (and prevents duplicate content if…

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,6 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>{{ if .IsPage }} {{ .Title }} | {{ end }}{{ .Site.Title }}</title>
+  <link rel = 'canonical' href = '{{ .Permalink }}'>
   {{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="all,follow">


### PR DESCRIPTION
Add canonical tag for improved SEO (and prevents duplicate content issues in search engines if deploying the site to multiple environments, such as staging and production)