### PR TITLE
Add possibility to include custom CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ hugo server
   colortheme = "white" # dark, light, white, or classic
 ```
 
+### Custom CSS
+
+```toml
+[params]
+  css = ["css/custom.css"]
+```
+
+You can add multiple custom stylesheets which will be loaded after the main theme css.
+For example, the above line will load the CSS-file placed at `/static/css/custom.css`.
+
 ### Navigation
 
 ```toml

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,6 +14,8 @@
   {{ end }}
   {{ $colortheme := .Scratch.Get "colortheme" }}
   <link rel="stylesheet" href="{{ $colortheme | printf "css/style-%s.css" | absURL }}">
+  <!-- Custom CSS -->
+  {{ range .Site.Params.css }} <link rel="stylesheet" href="{{ . | absURL }}"> {{ end }}
   {{ `
     <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>


### PR DESCRIPTION
I started using this theme for my personal blog, but quickly stumbled upon the missing possibility to add my own CSS.
As editing the CSS-files from the theme directly is not the best option (losing the possibility to update), I added the part in the `head.html` partial.

This way, CSS files can be added in the configuration, like updated in the README.
This would provide a way to add custom style sheets similar to other themes like [Minimal](https://themes.gohugo.io/minimal/).

Thanks for considering, this would be a great improvement!