### PR TITLE
Update "projectsurl" case in isset

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -93,7 +93,7 @@
   {{ end }}
   {{ if $showProjectsList }}
     {{ $projectsUrl := "#" }}
-    {{ if isset .Site.Params "projectsUrl" }}
+    {{ if isset .Site.Params "projectsurl" }}
       {{ $projectsUrl = .Site.Params.projectsUrl }}
     {{ end }}
   <section id="projects">


### PR DESCRIPTION
The custom projectUrl if statement is not working due to a case issue. According to Hugo's [documentation](https://gohugo.io/functions/isset/), using variables in isset statements should be all lowercase. This corrected the issue when I updated it in my source code.

> All site-level configuration keys are stored as lower case. Therefore, a myParam key-value set in your site configuration file needs to be accessed with {{if isset .Site.Params "myparam"}} and not with {{if isset .Site.Params "myParam"}}.