### PR TITLE
Add read time to posts

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -56,6 +56,7 @@ weight = 4
 
   # Post page settings
   show_updated = false # default
+  showReadTime = false # default
 
   [params.comments]
     enabled = false # default

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -39,6 +39,14 @@
             {{ end }}
         </div>
         {{ end }}
+        {{ $showReadTime := .Site.Params.showReadTime | default true }}
+        {{if $showReadTime}}
+        <div class="article-read-time">
+          <i class="far fa-clock"></i>
+          {{ $readTime := math.Round (div (countwords .Content) 220.0) }}
+          {{ $readTime }} minute read
+        </div>
+        {{ end }}
         {{ if gt .Params.tags 0 }}
         <div class="article-tag">
             <i class="fas fa-tag"></i>

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -30,6 +30,14 @@
             (Updated: <time datetime="{{ .Lastmod }}" itemprop="dateModified">{{ .Lastmod.Format $dataFormat }}</time>)
           {{ end }}
         </div>
+        {{ $showReadTime := .Site.Params.showReadTime | default false }}
+        {{if $showReadTime}}
+        <div class="article-read-time">
+          <i class="far fa-clock"></i>
+          {{ $readTime := math.Round (div (countwords .Content) 220.0) }}
+          {{ $readTime }} minute read
+        </div>
+        {{ end }}
         {{ if gt .Params.categories 0 }}
         <div class="article-category">
             <i class="fas fa-archive"></i>
@@ -37,14 +45,6 @@
             {{ if gt $index 0 }} {{ print ", " }} {{ end }}
             <a class="category-link" href="{{ "/categories/" | relLangURL }}{{ $value | urlize }}">{{ $value }}</a>
             {{ end }}
-        </div>
-        {{ end }}
-        {{ $showReadTime := .Site.Params.showReadTime | default false }}
-        {{if $showReadTime}}
-        <div class="article-read-time">
-          <i class="far fa-clock"></i>
-          {{ $readTime := math.Round (div (countwords .Content) 220.0) }}
-          {{ $readTime }} minute read
         </div>
         {{ end }}
         {{ if gt .Params.tags 0 }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -39,7 +39,7 @@
             {{ end }}
         </div>
         {{ end }}
-        {{ $showReadTime := .Site.Params.showReadTime | default true }}
+        {{ $showReadTime := .Site.Params.showReadTime | default false }}
         {{if $showReadTime}}
         <div class="article-read-time">
           <i class="far fa-clock"></i>

--- a/static/css/style-classic.css
+++ b/static/css/style-classic.css
@@ -1090,6 +1090,9 @@ article header .author {
   letter-spacing: 0.01em;
   font-weight: 700;
 }
+article header .article-read-time {
+  display: inline;
+}
 article header .postdate {
   display: inline;
 }
@@ -1207,6 +1210,7 @@ article .content .caption {
   .article-category {
     display: inline;
   }
+  .article-read-time:before,
   .article-tag:before,
   .article-category:before {
     content: "|";

--- a/static/css/style-dark.css
+++ b/static/css/style-dark.css
@@ -1090,6 +1090,9 @@ article header .author {
   letter-spacing: 0.01em;
   font-weight: 700;
 }
+article header .article-read-time {
+  display: inline;
+}
 article header .postdate {
   display: inline;
 }
@@ -1207,6 +1210,7 @@ article .content .caption {
   .article-category {
     display: inline;
   }
+  .article-read-time:before,
   .article-tag:before,
   .article-category:before {
     content: "|";

--- a/static/css/style-light.css
+++ b/static/css/style-light.css
@@ -1090,6 +1090,9 @@ article header .author {
   letter-spacing: 0.01em;
   font-weight: 700;
 }
+article header .article-read-time {
+  display: inline;
+}
 article header .postdate {
   display: inline;
 }
@@ -1207,6 +1210,7 @@ article .content .caption {
   .article-category {
     display: inline;
   }
+  .article-read-time:before,
   .article-tag:before,
   .article-category:before {
     content: "|";

--- a/static/css/style-white.css
+++ b/static/css/style-white.css
@@ -1106,6 +1106,9 @@
     letter-spacing: 0.01em;
     font-weight: 700;
   }
+  article header .article-read-time {
+    display: inline;
+  }
   article header .postdate {
     display: inline;
   }
@@ -1223,6 +1226,7 @@
     .article-category {
       display: inline;
     }
+    .article-read-time:before,
     .article-tag:before,
     .article-category:before {
       content: "|";


### PR DESCRIPTION
I added read-time to posts and made it configurable!

Here's a picture of it in action on the dark theme (thought it works on all themes):
![firefox_2021-04-04_05-06-12](https://user-images.githubusercontent.com/26174827/113508275-f2731180-9503-11eb-840c-bae6467d120a.png)

It's also configurable via the config with a new boolean setting, `showReadTime`, which I've set to default as false.

I updated the sample config in `exampleTheme` to reflect this as well.

