### PR TITLE
Example Site config file typo fix

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -44,7 +44,7 @@ weight = 4
 
   # Home page settings
   description = "Hugo is a general-purpose website framework. Technically speaking, Hugo is a static site generator. Unlike systems that dynamically build a page with each visitor request, Hugo builds pages when you create or update your content. Since websites are viewed far more often than they are edited, Hugo is designed to provide an optimal viewing experience for your website’s end users and an ideal writing experience for website authors."
-  mainSection = "posts" # your main section
+  mainSections = "posts" # your main section
   showAllPostsOnHomePage = false # default
   postsOnHomePage = 5 # this option will be ignored if showAllPostsOnHomePage is set to true
   tagsOverview = true # show tags overview by default.


### PR DESCRIPTION
Used the example site config file and wouldn't be able to make the `Writings` section work. The issue was with the config key.