### PR TITLE
Add aria-label to hamburger menu

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,7 +14,7 @@
   <div id="nav">
     <ul>
       <li class="icon">
-        <a href="#"><i class="fas fa-bars fa-2x"></i></a>
+        <a href="#" aria-label="Open the menu"><i class="fas fa-bars fa-2x" aria-hidden="true"></i></a>
       </li>
       {{ range .Site.Menus.main }}
         <li><a href="{{ .URL }}">{{ .Name }}</a></li>


### PR DESCRIPTION
After running Chrome's Lighthouse accessibility audit on this theme it
reported that the hamburger icon was inaccessible since it carried no
label. This commit adds a label for screen readers with the aria-label
property, which then passes the audit.