### PR TITLE
Theme has partial to have more sections in 'about'

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -34,6 +34,7 @@
       {{ end }}
       </p>
   {{ end }}
+  {{ partial "optional-about.html" . }}
   </section>
 
   <section id="writing">


### PR DESCRIPTION
Add a customization point to the main page's `about` section so that additional stuff can be put into it.

(My use case was: I wanted links to my resume to show up under the "socials".  So I have a partial which is swiped from setting up the "socials" only instead it iterates over `[[params.resume]]` and the icons are pulled from a different section of Font Awesome so I can get icons for pdfs and word docs.)