### PR TITLE
use $font-family-mono for code blocks

### DIFF
--- a/static/_styl/style.styl
+++ b/static/_styl/style.styl
@@ -147,6 +147,7 @@ code
   border: 1px dotted $color-border
   border-radius: 2px
   -webkit-border-radius: 2px
+  font-family: $font-family-mono
 
 .highlight
   overflow-x: auto


### PR DESCRIPTION
Prior to this change the font-family for code blocks was not set, this
meant it was inherited from the user agent stylesheet in the browser.
After this change we use the font set in $font-family-mono.