### PR TITLE
Allow setting the main section title

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ weight = 4
   mainSection = "posts"
 ```
 
+* change the default main section title from Writings, to something else:
+
+```toml
+[params]
+  mainSectionTitle = "Blog"
+```
+
 * Show only the 5 most recent posts (default)
 
 ```toml

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -37,7 +37,7 @@
   </section>
 
   <section id="writing">
-    <span class="h1"><a href="{{ .Site.Params.mainSection | absURL }}">Writings</a></span>
+    <span class="h1"><a href="{{ .Site.Params.mainSection | absURL }}">{{ .Site.Params.mainSectionTitle | default "Writings" }}</a></span>
     {{ if (and (and (isset .Site.Params "tagsoverview") (eq .Site.Params.tagsOverview true)) (gt (len .Site.Taxonomies.tags) 0)) }}
     <span class="h2">Topics</span>
     <span class="widget tagcloud">


### PR DESCRIPTION
Prior to this change the main section is always called "Writings". After
this change you can configure that value to for example match the title
you set in the main menu.