### PR TITLE
description: render as markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ weight = 4
 
 ### Homepage settings
 
-* description: description will be displayed in the homepage.
+* description: description will be displayed in the homepage. Markdown syntax is supported in the description string.
 ```toml
 [params]
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
   <section id="about">
   {{ if isset .Site.Params "description" }}
-    {{ .Site.Params.description }}
+    {{ .Site.Params.description | $.Page.RenderString }}
   {{ end }}
   {{ if isset .Site.Params "social" }}
       <p>Find me on


### PR DESCRIPTION
Prior to this change the description parameter was templated as a
string. This made it difficult to insert links or make text bold, as the
Go template engine escapes any html markup.

After this change the string is rendered with .RenderString which uses
the default page markup, markdown, to render the string.