### PR TITLE
Task sass to scss

### DIFF
--- a/assets/sass/_extend.sass
+++ b/assets/sass/_extend.sass
@@ -83,12 +83,12 @@ ol
 dl
   line-height: $line-height
 
-ul
-ol
-  ul
-  ol
-    margin-top: 0
-    margin-bottom: 0
+ul ul,
+ol ul,
+ul ol,
+ol ol 
+  margin-top: 0 
+  margin-bottom: 0 
 
 ol
   list-style: decimal

--- a/assets/sass/partial/article.sass
+++ b/assets/sass/partial/article.sass
@@ -131,6 +131,7 @@ article
     @include underline(10px, $color-link)
 
 @media (min-width: 480px)
+  .article-read-time,
   .article-tag,
   .article-category
     display: inline

--- a/assets/sass/partial/article.sass
+++ b/assets/sass/partial/article.sass
@@ -24,21 +24,22 @@ article
       display: inline
 
   .content
-    h2:before
-      position: absolute
-      top: -4px
-      left: -1rem
-      color: $color-accent-1
-      content: "#"
-      font-weight: bold
-      font-size: 1.2rem
+    h2
+      &:before
+        position: absolute
+        top: -4px
+        left: -1rem
+        color: $color-accent-1
+        content: "#"
+        font-weight: bold
+        font-size: 1.2rem
 
-    img
-    video
-      display: block
-      margin: auto
-      max-width: 100%
-      height: auto
+  .content img,
+  .content video
+    display: block
+    margin: auto
+    max-width: 100%
+    height: auto
 
     /* http://webdesignerwall.com/tutorials/css-elastic-videos */
     .video-container

--- a/assets/sass/partial/header.sass
+++ b/assets/sass/partial/header.sass
@@ -28,7 +28,7 @@
     border-radius: 5px
     background-size: $logo-width $logo-height
     background-repeat: no-repeat
-    if $logo-grayout
+    @if $logo-grayout
       filter: grayscale(100%)
       -webkit-filter: grayscale(100%)
 
@@ -69,7 +69,7 @@
         a
           margin-right: 0
 
-if $logo-grayout
+@if $logo-grayout
   #header:hover
     #logo
       filter: none

--- a/assets/sass/partial/post/actions_desktop.sass
+++ b/assets/sass/partial/post/actions_desktop.sass
@@ -23,7 +23,6 @@
       list-style-image: none;
       list-style-position: outside;
       list-style-type: none;
-      list-style-type: none;
       padding-inline-start: 40px;
       li
         display: list-item;

--- a/assets/sass/partial/tooltip.sass
+++ b/assets/sass/partial/tooltip.sass
@@ -10,7 +10,7 @@
   padding: .2em .5em
   -webkit-font-smoothing: subpixel-antialiased
   color: $color-background
-  font-display: swap // @stylint ignore
+  font-display: swap 
   font-weight: 400
   font-size: $font-size * 0.8
   font-family: $font-family-body

--- a/assets/sass/rtl.sass
+++ b/assets/sass/rtl.sass
@@ -1,28 +1,19 @@
 @font-face
   font-family: Vazir
   src: url('../lib/vazir-font/Vazir.eot')
-  src: url('../lib/vazir-font/Vazir.eot?#iefix') format('embedded-opentype'),
-       url('../lib/vazir-font/Vazir.woff2') format('woff2'),
-       url('../lib/vazir-font/Vazir.woff') format('woff'),
-       url('../lib/vazir-font/Vazir.ttf') format('truetype')
+  src: url("../lib/vazir-font/Vazir.eot?#iefix") format('embedded-opentype'), url("../lib/vazir-font/Vazir.woff2") format('woff2'), url("../lib/vazir-font/Vazir.woff") format('woff'), url("../lib/vazir-font/Vazir.ttf") format('truetype')
   font-weight: normal
 
 @font-face
   font-family: Vazir
   src: url('../lib/vazir-font/Vazir-Bold.eot')
-  src: url('../lib/vazir-font/Vazir-Bold.eot?#iefix') format('embedded-opentype'),
-       url('../lib/vazir-font/Vazir-Bold.woff2') format('woff2'),
-       url('../lib/vazir-font/Vazir-Bold.woff') format('woff'),
-       url('../lib/vazir-font/Vazir-Bold.ttf') format('truetype')
+  src: url("../lib/vazir-font/Vazir-Bold.eot?#iefix") format('embedded-opentype'), url("../lib/vazir-font/Vazir-Bold.woff2") format('woff2'), url("../lib/vazir-font/Vazir-Bold.woff") format('woff'), url("../lib/vazir-font/Vazir-Bold.ttf") format('truetype') 
   font-weight: bold
 
 @font-face
   font-family: Vazir
   src: url('../lib/vazir-font/Vazir-Light.eot')
-  src: url('../lib/vazir-font/Vazir-Light.eot?#iefix') format('embedded-opentype'),
-       url('../lib/vazir-font/Vazir-Light.woff2') format('woff2'),
-       url('../lib/vazir-font/Vazir-Light.woff') format('woff'),
-       url('../lib/vazir-font/Vazir-Light.ttf') format('truetype')
+  src: url("../lib/vazir-font/Vazir-Light.eot?#iefix") format('embedded-opentype'), url("../lib/vazir-font/Vazir-Light.woff2") format('woff2'), url("../lib/vazir-font/Vazir-Light.woff") format('woff'), url("../lib/vazir-font/Vazir-Light.ttf") format('truetype')
   font-weight: 300
 
 .rtl
@@ -31,14 +22,14 @@
 
   #nav
     li
-      margin-right: 0px !important // @stylint ignore
+      margin-right: 0px !important
       padding-left: 15px
-      border-right: 0px !important // @stylint ignore
+      border-right: 0px !important
       border-left: 1px dotted
 
     li:last-child
-      margin-right: 15px !important // @stylint ignore
-      border-left: 0 !important // @stylint ignore
+      margin-right: 15px !important
+      border-left: 0 !important
 
   #header
     #logo
@@ -54,8 +45,8 @@
       border-left: 1px dotted
 
     li:last-child
-      margin-right: 15px !important // @stylint ignore
-      border-left: 0 !important // @stylint ignore
+      margin-right: 15px !important
+      border-left: 0 !important
 
     #logo
       float: right

--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -23,7 +23,7 @@ body
   height: 100%
   background-color: $color-background
   color: $color-text
-  font-display: swap // @stylint ignore
+  font-display: swap
   font-weight: 400
   font-size: $font-size
   font-family: $font-family-body

--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -123,13 +123,10 @@ body
 @import "partial/tags"
 @import "partial/tooltip"
 @import "partial/categories"
-// Code
-// @import "highlight/" + $highlight
 
 pre
   overflow-x: auto
   padding: 10px 15px
-  padding-bottom: 0
   border: 1px dotted $color-border
   border-radius: 4px
   font-size: 13px
@@ -149,63 +146,6 @@ code
   -webkit-border-radius: 2px
 
 .highlight
-  overflow-x: auto
-  margin: 1rem 0
-  padding: 10px 15px
-  border-radius: 4px
-  background: $color-background-code
-  font-family: $font-family-mono
-  // color: $color-accent-3
-  -webkit-border-radius: 4px
-
-  figcaption
-    margin: -5px 0 5px
-    color: $color-meta-code
-    font-size: .9em
-    zoom: 1
-
-    a
-      float: right
-      color: $color-meta-code
-      font-style: italic
-      font-size: .8em
-      @include underline(10px, $color-link)
-
-    a:hover
-      color: lighten($color-meta-code,20%)
-
-    &:before
-      content: ""
-      display: table
-
-    &:after
-      clear: both
-
-  &:hover 
-    .btn-copy
-      opacity: 1
-
-  .btn-copy
-    font-size: 1.2rem
-    position: absolute
-    right: 20px
-    opacity: 0
-    transition: opacity 0.2s ease-in
-    &:hover
-      color: $color-accent-1
-
   pre
-    margin: 0
-    padding: 0
     border: none
     background: none
-
-  table
-    width: auto
-
-  td.gutter
-    text-align: right
-    opacity: .2
-
-  .line
-    height: 22px

--- a/assets/scss/_extend.scss
+++ b/assets/scss/_extend.scss
@@ -1,0 +1,119 @@
+// $base-style
+h1,
+.h1 {
+  display: block;
+  margin-top: 3rem;
+  margin-bottom: 1rem;
+  color: $color-accent-1;
+  letter-spacing: .01em;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 1.5em;
+
+  @include antialias();
+}
+h2,
+.h2 {
+  position: relative;
+  display: block;
+  margin-top: 2rem;
+  margin-bottom: .5rem;
+  color: $color-accent-2;
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: bold;
+  font-size: 1rem;
+}
+h3 {
+  color: $color-accent-2;
+  text-decoration: underline;
+  font-weight: bold;
+  font-size: .9rem;
+}
+h4
+h5
+h6 {
+  display: inline;
+  text-decoration: none;
+  color: $color-accent-3;
+  font-weight: bold;
+  font-size: .9rem;
+}
+h3
+h4
+h5
+h6 {
+  margin-top: .9rem;
+  margin-bottom: .5rem;
+}
+hr {
+  border: .5px dashed $color-accent-3;
+  opacity: .5;
+  margin: 0;
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+strong {
+  font-weight: bold;
+}
+em
+cite {
+  font-style: italic;
+}
+sup
+sub {
+  position: relative;
+  vertical-align: baseline;
+  font-size: .75em;
+  line-height: 0;
+}
+sup {
+  top: -.5em;
+}
+sub {
+  bottom: -.2em;
+}
+small {
+  font-size: .85em;
+}
+acronym
+abbr {
+  border-bottom: 1px dotted;
+}
+ul
+ol
+dl {
+  line-height: $line-height;
+}
+ul ul,
+ol ul,
+ul ol,
+ol ol {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+ol {
+  list-style: decimal;
+}
+dt {
+  font-weight: bold;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+  font-size: $font-size - 2px;
+  overflow: auto;
+  display: block;
+}
+th {
+  padding: 8px;
+  border-bottom: 1px dashed $color-border;
+  color: $color-accent-2;
+  font-weight: bold;
+  font-size: $font-size - 1px;
+}
+td {
+  padding: 0 8px;
+  border-bottom: none;
+}

--- a/assets/scss/_fonts.scss
+++ b/assets/scss/_fonts.scss
@@ -1,0 +1,11 @@
+@font-face {
+  font-style: normal;
+  font-family: "Meslo LG";
+  src: local("Meslo LG S"), url("../lib/meslo-LG/MesloLGS-Regular.ttf") format("truetype");
+}
+
+@font-face {
+  font-style: normal;
+  font-family: "JetBrains Mono";
+  src: local("JetBrains Mono"), url("../lib/JetBrainsMono/ttf/JetBrainsMono-Regular.ttf") format("truetype");
+};

--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -1,0 +1,20 @@
+@mixin antialias() {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+@mixin hyphens($value) {
+  hyphens: $value;
+  -moz-hyphens: $value;
+  -ms-hyphens: $value;
+  -webkit-hyphens: $value;
+}
+@mixin underline($size, $color) {
+  background-image: linear-gradient(transparent, transparent $size, $color $size, $color);
+  background-position: bottom;
+  background-size: 100% 6px;
+  background-repeat: repeat-x;
+}
+@mixin no-select() {
+  user-select: none;
+  -khtml-user-select: none;
+}

--- a/assets/scss/_util.scss
+++ b/assets/scss/_util.scss
@@ -1,0 +1,319 @@
+/* Basscss */
+.inline {
+  display: inline;
+}
+.block {
+  display: block;
+}
+.inline-block {
+  display: inline-block;
+}
+.table {
+  display: table;
+}
+.table-cell {
+  display: table-cell;
+}
+.overflow-hidden {
+  overflow: hidden;
+}
+.overflow-scroll {
+  overflow: scroll;
+}
+.overflow-auto {
+  overflow: auto;
+}
+.clearfix:before,
+.clearfix:after {
+  display: table;
+  content: " ";
+}
+.clearfix:after {
+  clear: both;
+}
+.left {
+  float: left;
+}
+.right {
+  float: right;
+}
+.fit {
+  max-width: 100%;
+}
+.truncate {
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.max-width-1 {
+  max-width: 24rem;
+}
+.max-width-2 {
+  max-width: 32rem;
+}
+.max-width-3 {
+  max-width: 48rem;
+}
+.max-width-4 {
+  max-width: 64rem;
+}
+.border-box {
+  box-sizing: border-box;
+}
+.m0 {
+  margin: 0;
+}
+.mt0 {
+  margin-top: 0;
+}
+.mr0 {
+  margin-right: 0;
+}
+.mb0 {
+  margin-bottom: 0;
+}
+.ml0 {
+  margin-left: 0;
+}
+.mx0 {
+  margin-right: 0;
+  margin-left: 0;
+}
+.my0 {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.m1 {
+  margin: .5rem;
+}
+.mt1 {
+  margin-top: .5rem;
+}
+.mr1 {
+  margin-right: .5rem;
+}
+.mb1 {
+  margin-bottom: .5rem;
+}
+.ml1 {
+  margin-left: .5rem;
+}
+.mx1 {
+  margin-right: .5rem;
+  margin-left: .5rem;
+}
+.my1 {
+  margin-top: .5rem;
+  margin-bottom: .5rem;
+}
+.m2 {
+  margin: 1rem;
+}
+.mt2 {
+  margin-top: 1rem;
+}
+.mr2 {
+  margin-right: 1rem;
+}
+.mb2 {
+  margin-bottom: 1rem;
+}
+.ml2 {
+  margin-left: 1rem;
+}
+.mx2 {
+  margin-right: 1rem;
+  margin-left: 1rem;
+}
+.my2 {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+.m3 {
+  margin: 2rem;
+}
+.mt3 {
+  margin-top: 2rem;
+}
+.mr3 {
+  margin-right: 2rem;
+}
+.mb3 {
+  margin-bottom: 2rem;
+}
+.ml3 {
+  margin-left: 2rem;
+}
+.mx3 {
+  margin-right: 2rem;
+  margin-left: 2rem;
+}
+.my3 {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+.m4 {
+  margin: 4rem;
+}
+.mt4 {
+  margin-top: 4rem;
+}
+.mr4 {
+  margin-right: 4rem;
+}
+.mb4 {
+  margin-bottom: 4rem;
+}
+.ml4 {
+  margin-left: 4rem;
+}
+.mx4 {
+  margin-right: 4rem;
+  margin-left: 4rem;
+}
+.my4 {
+  margin-top: 4rem;
+  margin-bottom: 4rem;
+}
+.mxn1 {
+  margin-right: -.5rem;
+  margin-left: -.5rem;
+}
+.mxn2 {
+  margin-right: -1rem;
+  margin-left: -1rem;
+}
+.mxn3 {
+  margin-right: -2rem;
+  margin-left: -2rem;
+}
+.mxn4 {
+  margin-right: -4rem;
+  margin-left: -4rem;
+}
+.ml-auto {
+  margin-left: auto;
+}
+.mr-auto {
+  margin-right: auto;
+}
+.mx-auto {
+  margin-right: auto;
+  margin-left: auto;
+}
+.p0 {
+  padding: 0;
+}
+.pt0 {
+  padding-top: 0;
+}
+.pr0 {
+  padding-right: 0;
+}
+.pb0 {
+  padding-bottom: 0;
+}
+.pl0 {
+  padding-left: 0;
+}
+.px0 {
+  padding-right: 0;
+  padding-left: 0;
+}
+.py0 {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+.p1 {
+  padding: .5rem;
+}
+.pt1 {
+  padding-top: .5rem;
+}
+.pr1 {
+  padding-right: .5rem;
+}
+.pb1 {
+  padding-bottom: .5rem;
+}
+.pl1 {
+  padding-left: .5rem;
+}
+.py1 {
+  padding-top: .5rem;
+  padding-bottom: .5rem;
+}
+.px1 {
+  padding-right: .5rem;
+  padding-left: .5rem;
+}
+.p2 {
+  padding: 1rem;
+}
+.pt2 {
+  padding-top: 1rem;
+}
+.pr2 {
+  padding-right: 1rem;
+}
+.pb2 {
+  padding-bottom: 1rem;
+}
+.pl2 {
+  padding-left: 1rem;
+}
+.py2 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+.px2 {
+  padding-right: 1rem;
+  padding-left: 1rem;
+}
+.p3 {
+  padding: 2rem;
+}
+.pt3 {
+  padding-top: 2rem;
+}
+.pr3 {
+  padding-right: 2rem;
+}
+.pb3 {
+  padding-bottom: 2rem;
+}
+.pl3 {
+  padding-left: 2rem;
+}
+.py3 {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+.px3 {
+  padding-right: 2rem;
+  padding-left: 2rem;
+}
+.p4 {
+  padding: 4rem;
+}
+.pt4 {
+  padding-top: 4rem;
+}
+.pr4 {
+  padding-right: 4rem;
+}
+.pb4 {
+  padding-bottom: 4rem;
+}
+.pl4 {
+  padding-left: 4rem;
+}
+.py4 {
+  padding-top: 4rem;
+  padding-bottom: 4rem;
+}
+.px4 {
+  padding-right: 4rem;
+  padding-left: 4rem;
+}

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -1,0 +1,13 @@
+// Fonts
+$font-family-body: "JetBrains Mono", monospace;
+$font-family-mono: "JetBrains Mono", monospace;
+$font-family-tt: "Inconsolata", monospace;
+$font-size: 14px;
+$line-height: 1.725;
+$page-width: 48rem;
+// Logo
+$logo-width: 50px;
+$logo-height: 50px;
+$logo-grayout: true;
+// Colors
+$colors: "dark" // white dark light classic

--- a/assets/scss/colors/classic.scss
+++ b/assets/scss/colors/classic.scss
@@ -1,0 +1,13 @@
+$color-background: #fafafa;
+$color-footer-mobile-1: darken($color-background, 2%);
+$color-footer-mobile-2: darken($color-background, 10%);
+$color-background-code: darken($color-background, 2%);
+$color-border: #666;
+$color-meta: #666;
+$color-meta-code: lighten($color-meta, 10%);
+$color-link: rgba(86, 124, 119, .4);
+$color-text: #22272a;
+$color-accent-1: #cc2a41;
+$color-accent-2: rgba(86, 124, 119, .8);
+$color-accent-3: #666;
+$color-quote: #cc2a41;

--- a/assets/scss/colors/dark.scss
+++ b/assets/scss/colors/dark.scss
@@ -1,0 +1,13 @@
+$color-background: #1d1f21;
+$color-footer-mobile-1: lighten($color-background, 2%);
+$color-footer-mobile-2: lighten($color-background, 10%);
+$color-background-code: lighten($color-background, 2%);
+$color-border: #666;
+$color-meta: #666;
+$color-meta-code: #666;
+$color-link: rgba(212, 128, 170, 1);
+$color-text: #c9cacc;
+$color-accent-3: #cccccc;
+$color-accent-2: #eeeeee;
+$color-accent-1: #2bbc8a;
+$color-quote: #ccffb6;

--- a/assets/scss/colors/light.scss
+++ b/assets/scss/colors/light.scss
@@ -1,0 +1,14 @@
+// by @GabiThume (https://github.com/gabithume)
+$color-background: #e2e0de;
+$color-footer-mobile-1: darken($color-background, 2%);
+$color-footer-mobile-2: darken($color-background, 10%);
+$color-background-code: darken($color-background, 2%);
+$color-border: #666;
+$color-meta: #666;
+$color-meta-code: lighten($color-meta, 10%);
+$color-link: rgba(43, 188, 138, 1);
+$color-text: #363533;
+$color-accent-3: #666666;
+$color-accent-2: #111111;
+$color-accent-1: #d44375;
+$color-quote: #ab2251;

--- a/assets/scss/colors/white.scss
+++ b/assets/scss/colors/white.scss
@@ -1,0 +1,14 @@
+// by @sergodeeva (https://github.com/sergodeeva)
+$color-background: #FFFFFF;
+$color-footer-mobile-1: darken($color-background, 2%);
+$color-footer-mobile-2: darken($color-background, 10%);
+$color-background-code: darken($color-background, 2%);
+$color-border: #666;
+$color-meta: #666;
+$color-meta-code: lighten($color-meta, 10%);
+$color-link: rgba(212, 128, 170, 1);
+$color-text: #383838;
+$color-accent-3: #8c8c8c;
+$color-accent-2: #383838;
+$color-accent-1: #2bbc8a;
+$color-quote: #2bbc8a;

--- a/assets/scss/partial/archive.scss
+++ b/assets/scss/partial/archive.scss
@@ -1,0 +1,32 @@
+#archive {
+  .post-list {
+    padding: 0;
+
+    .post-item {
+      margin-bottom: 1rem;
+      margin-left: 0;
+      list-style-type: none;
+
+      .meta {
+        display: block;
+        margin-right: 16px;
+        min-width: 100px;
+        color: $color-meta;
+        font-size: 14px;
+      }
+    }
+  }
+  @media (min-width: 480px) {
+    .post-list {
+      .post-item {
+        display: flex;
+        margin-bottom: 5px;
+        margin-left: 1rem;
+
+        .meta {
+          text-align: left;
+        }
+      }
+    }
+  }
+}

--- a/assets/scss/partial/article.scss
+++ b/assets/scss/partial/article.scss
@@ -1,0 +1,158 @@
+article {
+  header {
+    .posttitle {
+      margin-top: 0;
+      margin-bottom: 0;
+      text-transform: none;
+      font-size: 1.5em;
+      line-height: 1.25;
+    }
+    .meta {
+      margin-top: 0;
+      margin-bottom: 1rem;
+    }
+    .meta * {
+      color: $color-accent-3;
+      font-size: .85rem;
+    }
+    .author {
+      text-transform: uppercase;
+      letter-spacing: .01em;
+      font-weight: 700;
+    }
+    .postdate {
+      display: inline;
+    }
+  }
+  .content {
+    h2 {
+      &:before {
+        position: absolute;
+        top: -4px;
+        left: -1rem;
+        color: $color-accent-1;
+        content: "#";
+        font-weight: bold;
+        font-size: 1.2rem;
+      }
+    }
+  }
+  .content img,
+  .content video {
+    display: block;
+    margin: auto;
+    max-width: 100%;
+    height: auto;
+
+    /* http://webdesignerwall.com/tutorials/css-elastic-videos */
+    .video-container {
+      position: relative;
+      overflow: hidden;
+      padding-top: 56.25% e;
+      // (9/16 * 100)% // 16:9 ratio
+      height: 0;
+
+      iframe,
+      object,
+      embed {
+        position: absolute;
+        top: 0;
+        left: 0;
+        margin-top: 0;
+        width: 100%;
+        height: 100%;
+      }
+    }
+    blockquote {
+      margin: 1rem 10px;
+      padding: .5em 10px;
+      background: inherit;
+      color: $color-quote;
+      quotes: "\201C" "\201D" "\2018" "\2019";
+      font-weight: bold;
+
+      p {
+        margin: 0;
+      }
+      &:before {
+        margin-right: .25em;
+        color: $color-quote;
+        content: "\201C";
+        vertical-align: -.4em;
+        font-size: 2em;
+        line-height: .1em;
+      }
+      footer {
+        margin: line-height 0;
+        color: $color-meta;
+        font-size: 11px;
+
+        a {
+          background-image: linear-gradient(transparent, transparent 5px, $color-meta 5px, $color-meta);
+          color: $color-meta;
+        }
+        a:hover {
+          background-image: linear-gradient(transparent, transparent 4px, lighten($color-meta, 20%) 4px, lighten($color-meta, 20%));
+          color: lighten($color-meta, 20%);
+        }
+        cite {
+          &:before {
+            padding: 0 .5em;
+            content: "—";
+          }
+        }
+      }
+    }
+    .pullquote {
+      margin: 0;
+      width: 45%;
+      text-align: left;
+
+      &.left {
+        margin-right: 1em;
+        margin-left: .5em;
+      }
+      &.right {
+        margin-right: .5em;
+        margin-left: 1em;
+      }
+    }
+    .caption {
+      position: relative;
+      display: block;
+      margin-top: .5em;
+      color: $color-meta;
+      text-align: center;
+      font-size: .9em;
+    }
+  }
+}
+.posttitle {
+  text-transform: none;
+  font-size: 1.5em;
+  line-height: 1.25;
+}
+.article-tag {
+  .tag-link {
+    &:before {
+      content: "#";
+      @include underline(10px, $color-link);
+    }
+  }
+}
+.article-category {
+  .category-link {
+    @include underline(10px, $color-link);
+  }
+}
+@media (min-width: 480px) {
+  .article-read-time,
+  .article-tag,
+  .article-category {
+    display: inline;
+
+    &:before {
+      content: "|";
+    }
+  }
+};

--- a/assets/scss/partial/categories.scss
+++ b/assets/scss/partial/categories.scss
@@ -1,0 +1,18 @@
+#categories {
+  .category-list-title {
+    color: $color-meta;
+  }
+  .category-list {
+    .category-list-item {
+      .category-list-count {
+        color: $color-meta;
+      }
+      .category-list-count:before {
+        content: " (";
+      }
+      .category-list-count:after {
+        content: ")";
+      }
+    }
+  }
+}

--- a/assets/scss/partial/comments.scss
+++ b/assets/scss/partial/comments.scss
@@ -1,0 +1,3 @@
+.blog-post-comments {
+  margin-top: 4rem;
+}

--- a/assets/scss/partial/footer.scss
+++ b/assets/scss/partial/footer.scss
@@ -1,0 +1,66 @@
+#footer {
+  position: absolute;
+  bottom: 0;
+  margin-bottom: 10px;
+  width: 100%;
+  color: $color-meta;
+  vertical-align: top;
+  text-align: center;
+  font-size: 11px;
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  li {
+    display: inline-block;
+    margin-right: 15px;
+    border-right: 1px solid;
+    border-color: $color-border;
+    vertical-align: middle;
+
+    a {
+      margin-right: 15px;
+    }
+  }
+  li:last-child {
+    margin-right: 0;
+    border-right: 0;
+
+    a {
+      margin-right: 0;
+    }
+  }
+  a {
+    color: $color-meta;
+    text-decoration: underline;
+    background-image: none;
+  }
+  a:hover {
+    color: lighten($color-meta, 20%);
+  }
+  .footer-left {
+    height: 20px;
+    vertical-align: middle;
+    line-height: 20px;
+  }
+}
+@media (min-width: 39rem) {
+  #footer {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-between;
+    align-items: center;
+    align-content: center;
+    margin-bottom: 20px;
+
+    .footer-left {
+      align-self: flex-start;
+      margin-right: 20px;
+    }
+    .footer-right {
+      align-self: flex-end;
+    }
+  }
+};

--- a/assets/scss/partial/header.scss
+++ b/assets/scss/partial/header.scss
@@ -1,0 +1,123 @@
+#header {
+  margin: 0 auto 2rem;
+  width: 100%;
+
+  h1,
+  .h1 {
+    margin-top: 0;
+    margin-bottom: 0;
+    color: $color-text;
+    letter-spacing: .01em;
+    font-weight: 700;
+    font-style: normal;
+    font-size: 1.5rem;
+    line-height: 2rem;
+
+    @include antialias();
+  }
+  a {
+    background: none;
+    color: inherit;
+    text-decoration: none;
+  }
+  #logo {
+    display: inline-block;
+    float: left;
+    margin-right: 20px;
+    width: $logo-width;
+    height: $logo-height;
+    border-radius: 5px;
+    background-size: $logo-width $logo-height;
+    background-repeat: no-repeat;
+    @if $logo-grayout {
+      filter: grayscale(100%);
+      -webkit-filter: grayscale(100%);
+    }
+  }
+  #nav {
+    color: $color-accent-1;
+    letter-spacing: .01em;
+    font-weight: 200;
+    font-style: normal;
+    font-size: .8rem;
+
+    ul {
+      margin: 0;
+      padding: 0;
+      list-style-type: none;
+      line-height: 15px;
+
+      a {
+        margin-right: 15px;
+        color: $color-accent-1;
+      }
+      a:hover {
+        @include underline(5px, $color-accent-1);
+      }
+      li {
+        display: inline-block;
+        margin-right: 15px;
+        border-right: 1px dotted;
+        border-color: $color-accent-1;
+        vertical-align: middle;
+      }
+      .icon {
+        display: none;
+      }
+      li:last-child {
+        margin-right: 0;
+        border-right: 0;
+
+        a {
+          margin-right: 0;
+        }
+      }
+    }
+  }
+}
+@if $logo-grayout {
+  #header:hover {
+    #logo {
+      filter: none;
+      -webkit-filter: none;
+    }
+  }
+}
+@media screen and (max-width: 480px) {
+  #header #title {
+    display: table;
+    margin-right: 5rem;
+    min-height: $logo-height;
+    h1 {
+      display: table-cell;
+      vertical-align: middle;
+    }
+  }
+  #header #nav {
+    ul {
+      a:hover {
+        background: none;
+      }
+      li {
+        display: none;
+        border-right: 0;
+      }
+      li.icon {
+        position: absolute;
+        top: 77px;
+        right: 1rem;
+        display: inline-block;
+      }
+    }
+    ul.responsive {
+      li {
+        display: block;
+      }
+    }
+    li:not(:first-child) {
+      padding-top: 1rem;
+      padding-left: $logo-width + 20px;
+      font-size: 1rem;
+    }
+  }
+};

--- a/assets/scss/partial/index.scss
+++ b/assets/scss/partial/index.scss
@@ -1,0 +1,40 @@
+.post-list {
+  padding: 0;
+
+  .post-item {
+    margin-bottom: 1rem;
+    margin-left: 0;
+    list-style-type: none;
+
+    .meta {
+      display: block;
+      margin-right: 16px;
+      min-width: 100px;
+      color: $color-meta;
+      font-size: 14px;
+    }
+  }
+}
+@media (min-width: 480px) {
+  .post-list {
+    .post-item {
+      display: flex;
+      margin-bottom: 5px;
+
+      .meta {
+        text-align: left;
+      }
+    }
+  }
+}
+.project-list {
+  padding: 0;
+  list-style: none;
+
+  .project-item {
+    margin-bottom: 5px;
+    p {
+      display: inline;
+    }
+  }
+}

--- a/assets/scss/partial/pagination.scss
+++ b/assets/scss/partial/pagination.scss
@@ -1,0 +1,25 @@
+.pagination {
+  display: inline-block;
+  margin-top: 2rem;
+  width: 100%;
+  text-align: center;
+
+  .page-number {
+    color: $color-text;
+    font-size: .8rem;
+  }
+  a {
+    padding: 4px 6px;
+    border-radius: 5px;
+    // background-color: $color-accent-1
+    background-image: none;
+    color: $color-text;
+    text-decoration: none;
+  }
+  a:hover {
+    background-image: none;
+  }
+  a:hover:not(.active) {
+    color: $color-accent-2;
+  }
+}

--- a/assets/scss/partial/post/actions_desktop.scss
+++ b/assets/scss/partial/post/actions_desktop.scss
@@ -1,0 +1,256 @@
+#header-post {
+  position: fixed;
+  top: 2rem;
+  right: 0;
+  display: inline-block;
+  float: right;
+  z-index: 100;
+
+  a {
+    background: none;
+    color: inherit;
+    text-decoration: none;
+  }
+  a.icon {
+    background: none;
+
+    &:hover {
+      color: $color-link;
+    }
+  }
+  nav {
+    ul {
+      display: block;
+
+      list-style-image: none;
+
+      list-style-position: outside;
+
+      list-style-type: none;
+
+      padding-inline-start: 40px;
+
+      li {
+        display: list-item;
+
+        margin-right: 0px;
+      }
+    }
+  }
+  nav > ul {
+    margin-block-end: 1em;
+
+    margin-block-start: 1em;
+  }
+
+  ul {
+    display: inline-block;
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+
+    li {
+      display: inline-block;
+      margin-right: 15px;
+      vertical-align: middle;
+    }
+    li:last-child {
+      margin-right: 0;
+    }
+  }
+  #menu-icon {
+    float: right;
+    margin-right: 2rem;
+    margin-left: 15px;
+
+    &:hover {
+      color: $color-accent-1;
+    }
+  }
+  #menu-icon-tablet {
+    float: right;
+    margin-right: 2rem;
+    margin-left: 15px;
+
+    &:hover {
+      color: $color-accent-1;
+    }
+  }
+  #top-icon-tablet {
+    position: fixed;
+    right: 2rem;
+    bottom: 2rem;
+    margin-right: 2rem;
+    margin-left: 15px;
+
+    &:hover {
+      color: $color-accent-1;
+    }
+  }
+  .active {
+    color: $color-accent-1;
+  }
+  #menu {
+    visibility: hidden;
+    margin-right: 2rem;
+  }
+  #nav {
+    color: $color-accent-1;
+    letter-spacing: .01em;
+    font-weight: 200;
+    font-style: normal;
+    font-size: .8rem;
+
+    ul {
+      line-height: 15px;
+
+      a {
+        margin-right: 15px;
+        color: $color-accent-1;
+      }
+      a:hover {
+        @include underline(5px, $color-accent-1);
+      }
+      li {
+        border-right: 1px dotted $color-accent-1;
+      }
+      li:last-child {
+        margin-right: 0;
+        border-right: 0;
+
+        a {
+          margin-right: 0;
+        }
+      }
+    }
+  }
+  #actions {
+    float: right;
+    margin-top: 2rem;
+    margin-right: 2rem;
+    width: 100%;
+    text-align: right;
+
+    ul {
+      display: block;
+    }
+    .info {
+      display: block;
+      font-style: italic;
+    }
+  }
+  #share {
+    clear: both;
+    padding-top: 1rem;
+    padding-right: 2rem;
+    text-align: right;
+
+    li {
+      display: block;
+      margin: 0;
+    }
+  }
+  #toc {
+    float: right;
+    clear: both;
+    overflow: auto;
+    margin-top: 1rem;
+    padding-right: 2rem;
+    max-width: 20em;
+    max-height: calc(95vh - 7rem);
+    text-align: right;
+
+    a:hover {
+      color: $color-link;
+    }
+    // .toc-level-1 > .toc-link
+    //   display: none
+
+    nav > ul > li {
+      color: $color-text;
+      font-size: .8rem;
+
+      &:before {
+        color: $color-accent-1;
+        content: "#";
+        margin-right: 8px;
+      }
+    }
+    nav > ul > li > ul > li {
+      color: $color-meta;
+      font-size: .7rem;
+
+      &:before {
+        color: $color-accent-1;
+        content: "·";
+        font-weight: bold;
+        margin-right: 3px;
+      }
+    }
+    nav > ul > li > ul > li > ul > li {
+      color: darken($color-meta, 20%);
+      font-size: .4rem;
+    }
+    .toc-level-5 {
+      display: none;
+    }
+    .toc-level-6 {
+      display: none;
+    }
+    .toc-number {
+      display: none;
+    }
+// smartphone + phapblet
+  }
+}
+@media screen and (max-width: 500px) {
+  #header-post {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 900px) {
+  #header-post {
+    #menu-icon {
+      display: none;
+    }
+    #actions {
+      display: none;
+    }
+  }
+}
+@media screen and (max-width: 1199px) {
+  #header-post {
+    #toc {
+      display: none;
+    }
+  }
+}
+@media screen and (min-width: 900px) {
+  #header-post {
+    #menu-icon-tablet {
+      display: none !important;
+    }
+    #top-icon-tablet {
+      display: none !important;
+    }
+  }
+}
+@media screen and (min-width: 1199px) {
+  #header-post {
+    #actions {
+      width: auto;
+
+      ul {
+        display: inline-block;
+        float: right;
+      }
+      .info {
+        display: inline;
+        float: left;
+        margin-right: 2rem;
+        font-style: italic;
+      }
+    }
+  }
+};

--- a/assets/scss/partial/post/actions_mobile.scss
+++ b/assets/scss/partial/post/actions_mobile.scss
@@ -1,0 +1,154 @@
+#footer-post {
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 5000000;
+  width: 100%;
+  border-top: 1px solid $color-border;
+  background: $color-footer-mobile-1;
+  transition: opacity .2s;
+
+  a {
+    background: none;
+    color: inherit;
+    text-decoration: none;
+  }
+  a.icon {
+    background: none;
+
+    &:hover {
+      color: $color-link;
+    }
+  }
+  #nav-footer {
+    padding-right: 1rem;
+    padding-left: 1rem;
+    background: $color-footer-mobile-2;
+    text-align: center;
+
+    a {
+      color: $color-accent-1;
+      font-size: 1em;
+    }
+    a:hover {
+      @include underline(5px, $color-accent-1);
+    }
+    ul {
+      display: table;
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      list-style-type: none;
+
+      li {
+        display: inline-table;
+        padding: 10px;
+        width: 20%;
+        vertical-align: middle;
+      }
+    }
+  }
+  #actions-footer {
+    overflow: auto;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    padding-right: 1rem;
+    padding-left: 1rem;
+    width: 100%;
+    text-align: center;
+    white-space: nowrap;
+
+    a {
+      display: inline-block;
+      padding-left: 1rem;
+      color: $color-accent-1;
+    }
+  }
+  #share-footer {
+    padding-right: 1rem;
+    padding-left: 1rem;
+    background: $color-footer-mobile-2;
+    text-align: center;
+
+    ul {
+      display: table;
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      list-style-type: none;
+
+      li {
+        display: inline-table;
+        padding: 10px;
+        width: 20%;
+        vertical-align: middle;
+      }
+    }
+  }
+  #toc-footer {
+    clear: both;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+    background: $color-footer-mobile-2;
+    text-align: left;
+
+    #TableOfContents {
+      ul {
+        margin: 0;
+        padding-left: 20px;
+        list-style-type: none;
+
+        li {
+          line-height: 30px;
+        }
+      }
+    }
+    a:hover {
+      color: $color-link;
+    }
+    // .toc-level-1 > .toc-link
+    //   display: none
+
+    #TableOfContents > ul > li {
+      color: $color-text;
+      font-size: .8rem;
+
+      &:before {
+        color: $color-accent-1;
+        content: "#";
+        margin-right: 8px;
+      }
+    }
+    #TableOfContents > ul > li > ul > li {
+      color: $color-meta;
+      font-size: .7rem;
+      line-height: 15px;
+
+      &:before {
+        color: $color-accent-1;
+        content: "·";
+
+        font-weight: bold;
+
+        margin-right: 3px;
+      }
+    }
+    #TableOfContents > ul > li > ul > li > ul > li {
+      display: none;
+    }
+    // .toc-level-5
+    //   display: none
+
+    // .toc-level-6
+    //   display: none
+
+    // .toc-number
+    //   display: none
+  }
+}
+@media screen and (min-width: 500px) {
+  #footer-post-container {
+    display: none;
+  }
+};

--- a/assets/scss/partial/search.scss
+++ b/assets/scss/partial/search.scss
@@ -1,0 +1,49 @@
+.search-input {
+  padding: 4px 7px;
+  width: 100%;
+  outline: none;
+  border: solid 1px $color-accent-3;
+  border-radius: 5px;
+  background-color: $color-background;
+  color: $color-text;
+  font-size: 1.2rem;
+  -webkit-border-radius: 5px;
+  -moz-border-radius: 5px;
+
+  &:focus {
+    border: solid 1px $color-accent-1;
+  }
+}
+#search-result {
+  ul.search-result-list {
+    padding: 0;
+    list-style-type: none;
+  }
+  li {
+    margin: 2em auto;
+  }
+  a.search-result-title {
+    background-image: none;
+    color: $color-text;
+    text-transform: capitalize;
+    font-weight: bold;
+    line-height: 1.2;
+  }
+  p.search-result {
+    overflow: hidden;
+    margin: .4em auto;
+    max-height: 13em;
+    text-align: justify;
+    font-size: .8em;
+  }
+  em.search-keyword {
+    border-bottom: 1px dashed $color-link;
+    color: $color-link;
+    font-weight: bold;
+  }
+}
+.search-no-result {
+  display: none;
+  padding-bottom: .5em;
+  color: $color-text;
+}

--- a/assets/scss/partial/tags.scss
+++ b/assets/scss/partial/tags.scss
@@ -1,0 +1,13 @@
+#tag-cloud {
+  .tag-cloud-title {
+    color: $color-meta;
+  }
+  .tag-cloud-tags {
+    clear: both;
+    text-align: center;
+    a {
+      display: inline-block;
+      margin: 10px;
+    }
+  }
+}

--- a/assets/scss/partial/tooltip.scss
+++ b/assets/scss/partial/tooltip.scss
@@ -1,0 +1,86 @@
+// ref: https://github.com/primer/primer/blob/master/modules/primer-tooltips/lib/tooltips.scss
+.tooltipped {
+  position: relative;
+}  
+// This is the tooltip bubble
+.tooltipped::after {
+  position: absolute;
+  z-index: 1000000;
+  display: none;
+  padding: .2em .5em;
+  -webkit-font-smoothing: subpixel-antialiased;
+  color: $color-background;
+  font-display: swap;
+  font-weight: 400;
+  font-size: $font-size * 0.8;
+  font-family: $font-family-body;
+  line-height: $line-height;
+  text-rendering: geometricPrecision;
+  text-align: center;
+  word-wrap: break-word;
+  white-space: pre;
+  content: attr(aria-label);
+  background: $color-text;
+  border-radius: 3px;
+  opacity: 0;
+}  
+// This is the tooltip arrow
+.tooltipped::before {
+  position: absolute;
+  z-index: 1000001;
+  display: none;
+  width: 0;
+  height: 0;
+  color: $color-text;
+  pointer-events: none;
+  content: '';
+  border: 6px solid transparent;
+  opacity: 0;
+}  
+// delay animation for tooltip
+@keyframes tooltip-appear {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+};
+    
+// This will indicate when we'll activate the tooltip
+.tooltipped:hover,
+.tooltipped:active,
+.tooltipped:focus {
+  &::before,
+  &::after {
+    display: inline-block;
+    text-decoration: none;
+    animation-name: tooltip-appear;
+    animation-duration: 0.1s;
+    animation-fill-mode: forwards;
+    animation-timing-function: ease-in;
+  }    
+// Tooltipped south
+}
+.tooltipped-s,
+.tooltipped-sw {
+  &::after {
+    top: 100%;
+    right: 50%;
+    margin-top: 6px;
+  }
+  &::before {
+    top: auto;
+    right: 50%;
+    bottom: -7px;
+    margin-right: -6px;
+    border-bottom-color: $color-text;
+  }
+}
+.tooltipped-sw::after {
+  margin-right: -16px;
+}  
+// Move the tooltip body to the center of the object.
+.tooltipped-s::after {
+  transform: translateX(50%);
+}

--- a/assets/scss/rtl.scss
+++ b/assets/scss/rtl.scss
@@ -1,0 +1,105 @@
+@font-face {
+  font-family: Vazir;
+  src: url('../lib/vazir-font/Vazir.eot');
+  src: url("../lib/vazir-font/Vazir.eot?#iefix") format('embedded-opentype'), url("../lib/vazir-font/Vazir.woff2") format('woff2'), url("../lib/vazir-font/Vazir.woff") format('woff'), url("../lib/vazir-font/Vazir.ttf") format('truetype');
+  font-weight: normal;
+}
+
+@font-face {
+  font-family: Vazir;
+  src: url('../lib/vazir-font/Vazir-Bold.eot');
+  src: url("../lib/vazir-font/Vazir-Bold.eot?#iefix") format('embedded-opentype'), url("../lib/vazir-font/Vazir-Bold.woff2") format('woff2'), url("../lib/vazir-font/Vazir-Bold.woff") format('woff'), url("../lib/vazir-font/Vazir-Bold.ttf") format('truetype');
+  font-weight: bold;
+}
+
+@font-face {
+  font-family: Vazir;
+  src: url('../lib/vazir-font/Vazir-Light.eot');
+  src: url("../lib/vazir-font/Vazir-Light.eot?#iefix") format('embedded-opentype'), url("../lib/vazir-font/Vazir-Light.woff2") format('woff2'), url("../lib/vazir-font/Vazir-Light.woff") format('woff'), url("../lib/vazir-font/Vazir-Light.ttf") format('truetype');
+  font-weight: 300;
+}
+
+.rtl {
+  font-family: Vazir, sans-serif;
+  direction: rtl;
+
+  #nav {
+    li {
+      margin-right: 0px !important;
+      padding-left: 15px;
+      border-right: 0px !important;
+      border-left: 1px dotted;
+    }
+    li:last-child {
+      margin-right: 15px !important;
+      border-left: 0 !important;
+    }
+  }
+  #header {
+    #logo {
+      float: right;
+      margin-right: 0;
+      margin-left: 20px;
+    }
+  }
+  #footer {
+    li {
+      margin-right: 0px;
+      padding-left: 15px;
+      border-right: 0px;
+      border-left: 1px dotted;
+    }
+    li:last-child {
+      margin-right: 15px !important;
+      border-left: 0 !important;
+    }
+    #logo {
+      float: right;
+    }
+  }
+  article {
+    .content {
+      h2:before {
+        right: -1rem;
+      }
+    }
+  }
+  .post-list {
+    .post-item {
+      .meta {
+        margin-left: 16px;
+        margin-right: inherit;
+      }
+    }
+  }
+}
+@media screen and (min-width: 480px) {
+  .rtl {
+    .post-list {
+      .post-item {
+        .meta {
+          text-align: left;
+        }
+      }
+    }
+  }
+}
+@media screen and (max-width: 480px) {
+  .rtl {
+    #header {
+      #title {
+        margin-left: 5rem;
+        margin-right: 0;
+      }
+      #nav {
+        ul {
+          li {
+            left: 1rem;
+            right: auto;
+            border: 0;
+          }
+        }
+      }
+    }
+  }
+};

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -1,0 +1,178 @@
+@import "variables";
+@import "colors/{{ site.Params.colortheme }}";
+@import "util";
+@import "mixins";
+@import "extend";
+@import "fonts";
+
+// global-reset()
+
+*,
+*:before,
+*:after {
+  box-sizing: border-box;
+}
+html {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  border-top: 2px solid $color-text;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+}
+body {
+  margin: 0;
+  height: 100%;
+  background-color: $color-background;
+  color: $color-text;
+  font-display: swap;
+  font-weight: 400;
+  font-size: $font-size;
+  font-family: $font-family-body;
+  line-height: $line-height;
+  text-rendering: geometricPrecision;
+  flex: 1;
+
+  @include antialias();
+
+  @extend $base-style !optional;
+}
+.content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  overflow-wrap: break-word;
+
+  p {
+    @include hyphens(auto);
+  }
+  code {
+    @include hyphens(manual);
+  }
+  a {
+    color: $color-text;
+    text-decoration: none;
+
+    @include underline(5px, $color-text);
+
+    &:hover {
+      background-image: linear-gradient(transparent, transparent 4px, $color-link 4px, $color-link);
+    }
+  }
+  a.icon {
+    background: none;
+
+    &:hover {
+      color: $color-link;
+    }
+  }
+  h1 a,
+  .h1 a,
+  h2 a,
+  h3 a,
+  h4 a,
+  h5 a,
+  h6 a {
+    background: none;
+    color: inherit;
+    text-decoration: none;
+  }
+  h1 a:hover,
+  .h1 a:hover,
+  h2 a:hover,
+  h3 a:hover,
+  h4 a:hover,
+  h5 a:hover,
+  h6 a:hover {
+    @include underline(6px, $color-link);
+  }
+  h6 {
+    a {
+      background: none;
+      color: inherit;
+      text-decoration: none;
+    }
+  }
+  h6 {
+    a:hover {
+      @include underline(6px, $color-link);
+    }
+  }
+}
+@media (min-width: 540px) {
+  .image-wrap {
+    flex-direction: row;
+    margin-bottom: 2rem;
+
+    .image-block {
+      flex: 1 0 35%;
+      margin-right: 2rem;
+    }
+    p {
+      flex: 1 0 65%;
+    }
+  }
+}
+.max-width {
+  max-width: $page-width;
+}
+@media (max-width: 480px) {  // smaller margins at smaller screen widths
+  .px3 {
+    padding-right: 1rem;
+    padding-left: 1rem;
+  }
+  .my4 {
+    margin-top: 2rem;
+    margin-bottom: 2rem;
+  }
+}
+
+@media (min-width: 480px) {
+  p {
+    text-align: justify;
+  }
+}
+
+@import "partial/header";
+@import "partial/post/actions_desktop";
+@import "partial/post/actions_mobile";
+@import "partial/index";
+@import "partial/article";
+@import "partial/archive";
+@import "partial/comments";
+@import "partial/footer";
+@import "partial/pagination";
+@import "partial/search";
+@import "partial/tags";
+@import "partial/tooltip";
+@import "partial/categories";
+
+pre {
+  overflow-x: auto;
+  padding: 10px 15px;
+  border: 1px dotted $color-border;
+  border-radius: 4px;
+  font-size: 13px;
+  font-family: $font-family-mono;
+  line-height: 22px;
+  -webkit-border-radius: 4px;
+
+  code {
+    display: block;
+    padding: 0;
+    border: none;
+  }
+}
+code {
+  padding: 0 5px;
+  border: 1px dotted $color-border;
+  border-radius: 2px;
+  -webkit-border-radius: 2px;
+}
+.highlight {
+  pre {
+    border: none;
+    background: none;
+  }
+}

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,7 +1,7 @@
 baseURL = "https://example.com"
 languageCode = "en-us"
 title = "Cactus theme example"
-theme = "cactus"
+theme = "hugo-theme-cactus"
 copyright = "You" # cactus will use title if copyright is not set
 disqusShortname = "example" # Used when comments is enabled. Cactus will use site title if not set
 # googleAnalytics = "UA-1234-5"
@@ -35,6 +35,16 @@ weight = 4
     endLevel = 4
     ordered = false
     startLevel = 2
+  [markup.highlight]
+    codeFences = true
+    guessSyntax = false
+    hl_Lines = ""
+    lineNoStart = 1
+    lineNos = true
+    lineNumbersInTable = true
+    noClasses = true
+    style = "dracula"
+    tabWidth = 4
 
 [params]
 
@@ -55,8 +65,8 @@ weight = 4
   dateFormat = "2006-01-02" # default
 
   # Post page settings
-  show_updated = false # default
-  showReadTime = false # default
+  show_updated = true # default
+  showReadTime = true # default
 
   [params.comments]
     enabled = false # default

--- a/exampleSite/content/posts/code-block-test.md
+++ b/exampleSite/content/posts/code-block-test.md
@@ -1,0 +1,125 @@
+---
+title: Code Block Test
+date: 2021-06-27 09:00:00
+tags:
+    - test
+categories:
+    - tech
+keywords:
+    - markdown
+    - code block
+---
+
+
+`String`
+
+Using indents:
+
+    text
+    text
+    text
+
+
+Fenced code block:
+
+```
+text
+text
+<tag>
+```
+
+Fenced code block with language:
+
+```Java
+// Java
+public final class String
+    implements java.io.Serializable, Comparable<String>, CharSequence
+{
+    /** The value is used for character storage. */
+    private final char value[];
+
+    /** The offset is the first index of the storage that is used. */
+    private final int offset;
+
+    /** The count is the number of characters in the String. */
+    private final int count;
+
+    /** Cache the hash code for the string */
+    private int hash; // Default to 0
+
+    // ...
+
+    // Package private constructor which shares value array for speed.
+    String(int offset, int count, char value[]) {
+        this.value = value;
+        this.offset = offset;
+        this.count = count;
+    }
+
+    // ...
+
+    /**
+     * Returns a new string that is a substring of this string. The
+     * substring begins at the specified <code>beginIndex</code> and
+     * extends to the character at index <code>endIndex - 1</code>.
+     * Thus the length of the substring is <code>endIndex-beginIndex</code>.
+     * <p>
+     * Examples:
+     * <blockquote><pre>
+     * "hamburger".substring(4, 8) returns "urge"
+     * "smiles".substring(1, 5) returns "mile"
+     * </pre></blockquote>
+     *
+     * @param      beginIndex   the beginning index, inclusive.
+     * @param      endIndex     the ending index, exclusive.
+     * @return     the specified substring.
+     * @exception  IndexOutOfBoundsException  if the
+     *             <code>beginIndex</code> is negative, or
+     *             <code>endIndex</code> is larger than the length of
+     *             this <code>String</code> object, or
+     *             <code>beginIndex</code> is larger than
+     *             <code>endIndex</code>.
+     */
+    public String substring(int beginIndex, int endIndex) {
+        if (beginIndex < 0) {
+            throw new StringIndexOutOfBoundsException(beginIndex);
+        }
+        if (endIndex > count) {
+            throw new StringIndexOutOfBoundsException(endIndex);
+        }
+        if (beginIndex > endIndex) {
+            throw new StringIndexOutOfBoundsException(endIndex - beginIndex);
+        }
+        return ((beginIndex == 0) && (endIndex == count)) ? this :
+            new String(offset + beginIndex, endIndex - beginIndex, value);
+    }
+
+    // ...
+}
+```
+
+Using hugo's `highlight` [shortcode]([highlight](https://gohugo.io/content-management/syntax-highlighting/#highlight-shortcode)):
+
+{{< highlight typescript "linenos=table, hl_lines=8 18-21" >}}
+// TypeScript
+type OptionalUser = {
+    [K in keyof User]?: User[K]
+}
+
+// ! we can remove optional constraint
+type RequiredUser = {
+    [K in keyof OptionalUser]-?: User[K]
+}
+
+type NullableUser = {
+    [K in keyof User]: User[K] | null
+}
+type ReadonlyUser = {
+    readonly [K in keyof User]: User[K]
+}
+
+// ! we can remove readonly constraint
+type ModifiableUser = {
+    -readonly [K in keyof User]: User[K]
+}
+{{< /highlight >}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,7 +15,7 @@
   {{ $colortheme := .Scratch.Get "colortheme" }}
 
   {{- $options := (dict "targetPath" "css/styles.css" "outputStyle" "compressed" "enableSourceMap" "true") -}}
-  {{- $styles := resources.Get "sass/style.sass" | resources.ExecuteAsTemplate "sass/style.sass" . | resources.ToCSS $options | resources.Fingerprint "sha512" }}
+  {{- $styles := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "scss/style.scss" . | resources.ToCSS $options | resources.Fingerprint "sha512" }}
   <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}"> 
 
   <!-- Custom CSS -->


### PR DESCRIPTION
The reasons to use SCSS syntax instead of Sass are listed below:

* SCSS is much close to CSS.
* Almost all guidelines and resources are using SCSS.
* Lint tools like Stylelint, only support SCSS. We can easily lint and auto-fix our SCSS codes.

https://sass-guidelin.es/#sass-or-scss

https://stylelint.io/user-guide/get-started#your-configuration
