### PR TITLE
Add colortheme setting to install README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ git clone https://github.com/monkeyWzr/hugo-theme-cactus.git themes/cactus
 # config.toml
 
 theme = "cactus"
+
+[params]
+
+  colortheme = "white" # dark, light, white, or classic
 ```
 
 3. config your site. See [Config] or a [complete config sample](exampleSite/config.toml)


### PR DESCRIPTION
Add `colortheme` params during install, otherwise build errors:

```
WARNING: calling IsSet with unsupported type "ptr" (*hugolib.SiteInfo) will always return false.
Error: Error building site: TOCSS: failed to transform "scss/style.scss" (text/x-scss): SCSS processing failed: file "stdin", line 2, col 1: File to import not found or unreadable: colors/<no value>. 
```