### PR TITLE
Add crossorigin attribute to stylesheet

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -21,7 +21,7 @@
 
   {{- $options := (dict "targetPath" "css/styles.css" "outputStyle" "compressed" "enableSourceMap" "true") -}}
   {{- $styles := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "scss/style.scss" . | resources.ToCSS $options | resources.Fingerprint "sha512" }}
-  <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}"> 
+  <link rel="stylesheet" href="{{ $styles.Permalink }}">
 
   <!-- Custom CSS -->
   {{ range .Site.Params.css }} <link rel="stylesheet" href="{{ . | absURL }}"> {{ end }}


### PR DESCRIPTION
First of all thanks for the neat theme.
I've added a `crossorigin` attribute (following [this][1] post) to the stylesheet link as it looks the only solution to a problem I am currently facing and seems it's a shared approach on other themes as well.
![image](https://user-images.githubusercontent.com/29178712/125591275-c6c63a74-9355-4356-bbee-a5b8c31a7752.png)

[1]: https://discourse.gohugo.io/t/howto-add-subresource-integrity-support-to-your-theme/5636/2