### PR TITLE
Fix annoying warning: "WARNING: calling IsSet with unsupported type "…

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -12,12 +12,12 @@
         {{ .Title }}
       </h1>
       <div class="meta">
-        {{ if (or (isset .Site "author") (isset .Site "title"))}}
+        {{ if (or (.Site.Author) (.Site.Title))}}
         <span class="author" itemprop="author" itemscope itemtype="http://schema.org/Person">
           <span itemprop="name">
-            {{ if isset .Site "author" }}
+            {{ if .Site.Author }}
               {{ .Site.Author }}
-            {{ else if isset .Site "title" }}
+            {{ else if .Site.Title }}
               {{ .Site.Title }}
             {{ end }}
           </span>


### PR DESCRIPTION
Fixes: 

`WARNING: calling IsSet with unsupported type "ptr" (*hugolib.SiteInfo) will always return false.`