### PR TITLE
Add tocInline, enables an inline toc on blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ weight = 4
   tagsOverview = true
 ```
 
+* display the table of contents inline on blog posts, rather than as part of the navigation menu:
+
+```toml
+[params]
+  tocInline = true
+```
+
 * show projects list (default) or not.
 
 ```toml

--- a/layouts/partials/page_nav.html
+++ b/layouts/partials/page_nav.html
@@ -48,8 +48,10 @@
       {{ .Scratch.Set "icon_class_name" ""}}
       {{ partial "share.html" . }}
     </div>
+    {{ if not .Site.Params.tocInline }}
     <div id="toc">
       {{ .TableOfContents }}
     </div>
+    {{ end }}
   </span>
 </div>

--- a/layouts/partials/page_nav_mobile.html
+++ b/layouts/partials/page_nav_mobile.html
@@ -9,9 +9,11 @@
       </ul>
     </div>
 
+    {{ if not .Site.Params.tocInline }}
     <div id="toc-footer" style="display: none">
       {{ .TableOfContents }}
     </div>
+    {{ end }}
 
     <div id="share-footer" style="display: none">
       {{ .Scratch.Set "icon_class_name" "fa-lg" }}
@@ -22,8 +24,10 @@
       <!-- TODO: rewrite the toggle function. hide the others when one menu is displayed -->
         <a id="menu-toggle" class="icon" href="#" onclick="$('#nav-footer').toggle();return false;" aria-label="Menu">
           <i class="fas fa-bars fa-lg" aria-hidden="true"></i> Menu</a>
+        {{ if not .Site.Params.tocInline }}
         <a id="toc-toggle" class="icon" href="#" onclick="$('#toc-footer').toggle();return false;" aria-label="TOC">
           <i class="fas fa-list fa-lg" aria-hidden="true"></i> TOC</a>
+        {{ end }}
         <a id="share-toggle" class="icon" href="#" onclick="$('#share-footer').toggle();return false;" aria-label="Share">
           <i class="fas fa-share-alt fa-lg" aria-hidden="true"></i> share</a>
         <a id="top" style="display:none" class="icon" href="#" onclick="$('html, body').animate({ scrollTop: 0 }, 'fast');" aria-label="Top of Page">

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -68,6 +68,11 @@
       {{ end }}
     </div>
   {{ end }}
+    {{ if .Site.Params.tocInline }}
+    <div id="toc">
+      {{ .TableOfContents }}
+    </div>
+    {{ end }}
     <div class="content" itemprop="articleBody">
       {{ .Content}}
     </div>


### PR DESCRIPTION
Setting tocInline to true displays the table of contents inline on blog
posts, rather than as part of the navigation menu.