### PR TITLE
Added utteranc.es and Cactus Comments support

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -70,8 +70,16 @@ weight = 4
   showReadTime = true # default
 
   [params.comments]
-    enabled = false # default
-    engine = "disqus" # more supported engines will be added.
+    enabled = true # default
+    engine = "cactus_comments" # only disqus, utterances, and cactus_comments is supported
+    [params.comments.utterances]
+      repo = "<github_username>/<github_reponame>"
+      label = "hugo-site-name" # you can use however you want to label your name in your repo's issues
+      theme = "github-light"
+    [params.comments.cactuscomments]
+      siteName = "your_cactus_comments_sitename" # see https://cactus.chat/ on how to register your site name
+      #serverUrl = "" # Defaults to https://matrix.cactus.chat:8448 (Cactus Chat public server)
+      #serverName = "" # Defaults to cactus.chat
 
   # the value of name should be an valid font awesome icon name (brands type)
   # https://fontawesome.com/icons?d=gallery&s=brands

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -10,27 +10,13 @@
 
 {{ $enable_comments := .Scratch.Get "enable_comments" }}
 {{ if $enable_comments }}
-  {{ if (or (not (isset .Site.Params.Comments "engine")) (eq .Site.Params.Comments.Engine "disqus")) }}
-    <div class="blog-post-comments">
-        <div id="disqus_thread">
-          <script type="text/javascript">
-          
-          (function() {
-              // Don't ever inject Disqus on localhost--it creates unwanted
-              // discussions from 'localhost:1313' on your Disqus account...
-              // if (window.location.hostname == "localhost")
-              //     return;
-          
-              var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-              var disqus_shortname = '{{ if .Site.DisqusShortname }}{{ .Site.DisqusShortname }}{{ else }}{{ .Site.Title }}{{ end }}';
-              dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-              (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-          })();
-          </script>
-          <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-          <a href="https://disqus.com/" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
-        </div>
-    </div>
-
-  {{ end }}
+  <div class="blog-post-comments">
+    {{ if (or (not (isset .Site.Params.Comments "engine")) (eq .Site.Params.Comments.Engine "disqus")) }}
+      {{ partial "comments/disqus.html" . }}
+    {{ else if eq .Site.Params.Comments.Engine "utterances" }}
+      {{ partial "comments/utterances.html" . }}
+    {{ else if eq .Site.Params.Comments.Engine "cactus_comments" }}
+      {{ partial "comments/cactus_comments.html" . }}
+    {{ end }}
+  </div>
 {{ end }}

--- a/layouts/partials/comments/cactus_comments.html
+++ b/layouts/partials/comments/cactus_comments.html
@@ -1,0 +1,11 @@
+<div id="cactus-comments-thread">
+  <script>
+  initComments({
+    node: document.getElementById("cactus-comments-thread"),
+    defaultHomeserverUrl: '{{ default "https://matrix.cactus.chat:8448" .Site.Params.Comments.Cactuscomments.ServerUrl }}',
+    serverName: '{{ default "cactus.chat" .Site.Params.Comments.Cactuscomments.ServerName }}',
+    siteName: "{{ .Site.Params.Comments.Cactuscomments.SiteName }}",
+    commentSectionId: "{{ .RelPermalink }}"
+  })
+</script>
+</div>

--- a/layouts/partials/comments/disqus.html
+++ b/layouts/partials/comments/disqus.html
@@ -1,0 +1,17 @@
+<div id="disqus_thread">
+  <script type="text/javascript">
+    (function() {
+      // Don't ever inject Disqus on localhost--it creates unwanted
+      // discussions from 'localhost:1313' on your Disqus account...
+      // if (window.location.hostname == "localhost")
+      //     return;
+    
+      var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+      var disqus_shortname = '{{ if .Site.DisqusShortname }}{{ .Site.DisqusShortname }}{{ else }}{{ .Site.Title }}{{ end }}';
+      dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+      (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    })();
+  </script>
+  <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+  <a href="https://disqus.com/" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+</div>

--- a/layouts/partials/comments/utterances.html
+++ b/layouts/partials/comments/utterances.html
@@ -1,0 +1,10 @@
+<div id="disquss_thread">
+  <script src="https://utteranc.es/client.js"
+    repo="{{ .Site.Params.Comments.Utterances.Repo }}"
+    issue-term="pathname"
+    label="{{ .Site.Params.Comments.Utterances.Label }}"
+    theme="{{ .Site.Params.Comments.Utterances.Theme }}"
+    crossorigin="anonymous"
+    async>
+  </script>
+</div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,6 +3,8 @@
   <link rel="preload" href="{{ "lib/font-awesome/webfonts/fa-regular-400.woff2" | relURL }}" as="font" type="font/woff2" crossorigin="anonymous">
   <link rel="preload" href="{{ "lib/font-awesome/webfonts/fa-solid-900.woff2" | relURL }}" as="font" type="font/woff2" crossorigin="anonymous">
   <link rel="preload" href="{{ "lib/JetBrainsMono/web/woff2/JetBrainsMono-Regular.woff2" | relURL }}" as="font" type="font/woff2" crossorigin="anonymous">
+  <script type="text/javascript" src="https://latest.cactus.chat/cactus.js"></script>
+  <link rel="stylesheet" href="https://latest.cactus.chat/style.css" type="text/css">
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>{{ if .IsPage }} {{ .Title }} | {{ end }}{{ .Site.Title }}</title>


### PR DESCRIPTION
Hello,

I removed my previous pull request for adding utteranc.es since there was already a pull request for that. Instead, I wanted to submit this one that includes both utteranc.es and Cactus Comments (not to be confused with the Cactus theme here) as separate partials... Cactus Comments is the one that uses the matrix protocol.

I moved disqus to a separate partial, and added cactus_comments and utterances as separate partials. I tested the three different comment engines and they all work well (using Hugo version 0.86.1).

I also included the config.toml in the exampleSite for the new parameters. Also, head.html needed a couple lines for css and javascript sources that are used for Cactus Comments.