### PR TITLE
Fixed mainSection Param

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -57,7 +57,7 @@
       {{ $showAllPostsOnHomePage = .Site.Params.ShowAllPostsOnHomePage }}
     {{ end }}
     {{ $dataFormat := .Site.Params.dateFormat | default "2006-01-02" }}
-    {{ $mainPosts := (sort ( where site.RegularPages "Type" "in" site.Params.mainSections ) "Date" "desc") }}
+    {{ $mainPosts := (sort ( where site.RegularPages "Type" "in" site.Params.mainSection ) "Date" "desc") }}
     {{ if $showAllPostsOnHomePage }}
     <ul class="post-list">
       {{ range (.Paginate $mainPosts).Pages }}


### PR DESCRIPTION
`mainSection` was introduced in config.toml but `site.Params.mainSections` is called in the index.html file.
The home page is using an arbitrary content folder for `mainPosts` instead of from defined mainSection due to this.