### PR TITLE
bunch of additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ default config:
 
 ### Analytics
 
+#### Google Analytics
+
 Cactus uses hugo's bulit in analytics templates. Check [hugo's documents](https://gohugo.io/templates/internal#google-analytics) for details.
 
 Set you tracking id in your site config.
@@ -244,6 +246,28 @@ If you are using Google Analytics v3 (analytics.js), you can switch to asynchron
 ```toml
 [params]
 googleAnalyticsAsync = true # not required
+```
+
+#### Matomo
+
+Matomo can be configured by adding the [Hugo Matomo Module](https://github.com/holehan/hugo-component-matomo) and updating `config.toml` like this:
+
+```toml
+# in config.toml
+
+[[module.imports]]
+  path = 'github.com/holehan/hugo-components-matomo'
+
+[params]
+
+  # and add this line
+  [params.analytics.matomo]
+
+  # configure matomo settings, in detail described here:
+  # https://github.com/holehan/hugo-component-matomo
+  [params.matomo]
+    url = "https://example.org"
+    id = 1
 ```
 
 ### RSS

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Comments is disabled by default. Enable comments in your `.Site.Params`.
 [params]
   [params.comments]
     enabled = true
+    insert_hr_line = false # inserts an <hr> element before comment block
     engine = "disqus" # default if unset
                       # other options: disqus, utterances, cactus_comments, remark42
 ```

--- a/README.md
+++ b/README.md
@@ -306,6 +306,17 @@ Pagination on posts archive can be disabled to show all posts in chronological o
   showAllPostsArchive = true # or false (default)
 ```
 
+### Page image gallery
+
+If you have images in your page bundle the theme will add them at the top of your page.
+You can disable this behavior in `config.toml`.
+
+```toml
+# config.toml
+[params]
+  disable_gallery = true
+```
+
 ## TODOS
 
 - [ ] More comments engines

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Comments is disabled by default. Enable comments in your `.Site.Params`.
   [params.comments]
     enabled = true
     engine = "disqus" # default if unset
-                      # other options: disqus, utterances, cactus_comments
+                      # other options: disqus, utterances, cactus_comments, remark42
 ```
 
 You can also enable/disable comments per post. in your posts' front matter, add:
@@ -213,6 +213,18 @@ Before using disqus, you need to register and get your [disqus shortname](https:
 
 ```
 disqusShortname = "wzr" # cactus will use site title if not set
+```
+
+#### Remark42 configuration
+
+```toml
+  [params.comments.remark42]
+    site_id = "changeme"              # REQUIRED
+    url = "https://my.remark42.url"   # REQUIRED
+    #locale = "en"                     # select locale, default "en"
+    #max_comments = 15                 # display that many comments, default 15
+    #simple_view = false               # enable simple view (no noticable effect?)
+    #theme = "light"                   # "light" | "dark", default "light"
 ```
 
 ### highlight

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Some works are still in progress. See [TODOS](#todos) below.
 
 ## Install
 
+### As Hugo module (preferred)
+
+```toml
+# config.toml
+theme = "github.com/flypenguin/hugo-theme-cactus"
+```
+
+Now continue with step 3 below.
+
+### As git submodule
+
 1. clone cactus to your hugo site's `themes` folder.
 ```
 git clone https://github.com/monkeyWzr/hugo-theme-cactus.git themes/cactus

--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ comments: true
 
 The site config is ignored when `comments` option exists in front matter.
 
-The default engine is disqus. **By now only disqus is supported in cactus.** I will add more options sooner or later. See [Comments Alternatives](https://gohugo.io/content-management/comments/#comments-alternatives)
+#### Disqus notes
+
+The default engine is disqus.
 
 Before using disqus, you need to register and get your [disqus shortname](https://help.disqus.com/en/articles/1717111-what-s-a-shortname). Assign your shortname in `.Site.disqusShortname`, or cactus will use `.Site.Title` by default.
 

--- a/README.md
+++ b/README.md
@@ -193,10 +193,12 @@ Comments is disabled by default. Enable comments in your `.Site.Params`.
 [params]
   [params.comments]
     enabled = true
-    # engine = "disqus" # in progress
+    engine = "disqus" # default if unset
+                      # other options: disqus, utterances, cactus_comments
 ```
 
 You can also enable/disable comments per post. in your posts' front matter, add:
+
 ```yaml
 comments: true
 ```

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,4 +17,7 @@
 <link rel="stylesheet" href={{ "lib/font-awesome/css/all.min.css" | relURL }}>
 <script src={{ "lib/jquery/jquery.min.js" | relURL }}></script>
 <script src={{ "js/main.js" | relURL }}></script>
+{{- if (isset .Site.Params.analytics  "matomo")  }}
+{{ partial "matomo-tracking" . }}
+{{- end  }}
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 {{ partial "head.html" . }}
+
 <body class="max-width mx-auto px3 ltr">
   <div class="content index py4">
 
@@ -17,7 +18,8 @@
 <link rel="stylesheet" href={{ "lib/font-awesome/css/all.min.css" | relURL }}>
 <script src={{ "lib/jquery/jquery.min.js" | relURL }}></script>
 <script src={{ "js/main.js" | relURL }}></script>
-{{- if (isset .Site.Params.analytics  "matomo")  }}
+{{- if (isset .Site.Params "matomo") }}
 {{ partial "matomo-tracking" . }}
-{{- end  }}
+{{- end }}
+
 </html>

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,5 +1,7 @@
 {{ $enable_comments := .Scratch.Get "enable_comments" }}
 {{ if $enable_comments -}}
+{{- if .Site.Params.Comments.insert_hr_line -}}<hr/>
+{{ end -}}
   <div class="blog-post-comments">
     {{ if (or (not (isset .Site.Params.Comments "engine")) (eq .Site.Params.Comments.Engine "disqus")) }}
       {{ partial "comments/disqus.html" . }}

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,15 +1,5 @@
-{{ if (not (isset .Site.Params "comments")) }}
-  {{ .Scratch.Set "enable_comments" false }}
-{{ else if (isset .Params "comments") }}
-  {{ .Scratch.Set "enable_comments" .Params.comments }}
-{{ else if (isset .Site.Params.Comments "enabled") }}
-  {{ .Scratch.Set "enable_comments" .Site.Params.Comments.Enabled }}
-{{ else }}
-  {{ .Scratch.Set "enable_comments" true }}
-{{ end }}
-
 {{ $enable_comments := .Scratch.Get "enable_comments" }}
-{{ if $enable_comments }}
+{{ if $enable_comments -}}
   <div class="blog-post-comments">
     {{ if (or (not (isset .Site.Params.Comments "engine")) (eq .Site.Params.Comments.Engine "disqus")) }}
       {{ partial "comments/disqus.html" . }}

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -7,6 +7,8 @@
       {{ partial "comments/utterances.html" . }}
     {{ else if eq .Site.Params.Comments.Engine "cactus_comments" }}
       {{ partial "comments/cactus_comments.html" . }}
+    {{ else if eq .Site.Params.Comments.Engine "remark42" }}
+      {{ partial "comments/remark42.html" . }}
     {{ end }}
   </div>
 {{ end }}

--- a/layouts/partials/comments/remark42.html
+++ b/layouts/partials/comments/remark42.html
@@ -1,0 +1,26 @@
+    <div id="remark42"></div>
+    <script type="text/javascript">
+        {{ `// docs see here: https://github.com/umputun/remark42#comments` | safeJS }}
+        var remark_config = {
+            host: {{ .Site.Params.comments.remark42.url | default "https://CHANGE.ME.IN.CONFIG.TOML" }},
+            site_id: {{ .Site.Params.comments.remark42.site_id | default "CHANGE ME IN CONFIG.TOML" }},
+            components: ['embed'],
+            url: {{ .Permalink }},
+            max_shown_comments: {{ .Site.Params.comments.remark42.max_comments | default 15 }},
+            theme: {{ .Site.Params.comments.remark42.theme | default "light" }},
+            page_title: {{ .Title }},
+            locale: {{ .Site.Params.comments.remark42.locale | default "en" }},
+            show_email_subscription: false,
+            simple_view: {{ .Site.Params.comments.remark42.simple_view | default false }}
+        };
+    </script>
+    <script>
+        ! function(e, n) {
+            for (var o = 0; o < e.length; o++) {
+                var r = n.createElement("script"),
+                    c = ".js",
+                    d = n.head || n.body;
+                "noModule" in r ? (r.type = "module", c = ".mjs") : r.async = !0, r.defer = !0, r.src = remark_config.host + "/web/" + e[o] + c, d.appendChild(r)
+            }
+        }(remark_config.components || ["embed"], document);
+    </script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,12 +1,22 @@
+{{ if (not (isset .Site.Params "comments")) -}}
+  {{ .Scratch.Set "enable_comments" false -}}
+{{ else if (isset .Params "comments") -}}
+  {{ .Scratch.Set "enable_comments" .Params.comments -}}
+{{ else if (isset .Site.Params.Comments "enabled") -}}
+  {{ .Scratch.Set "enable_comments" .Site.Params.Comments.Enabled -}}
+{{ else -}}
+  {{ .Scratch.Set "enable_comments" true -}}
+{{ end -}}
+{{ $enable_comments := .Scratch.Get "enable_comments" -}}
 <head>
   <link rel="preload" href="{{ "lib/font-awesome/webfonts/fa-brands-400.woff2" | relURL }}" as="font" type="font/woff2" crossorigin="anonymous">
   <link rel="preload" href="{{ "lib/font-awesome/webfonts/fa-regular-400.woff2" | relURL }}" as="font" type="font/woff2" crossorigin="anonymous">
   <link rel="preload" href="{{ "lib/font-awesome/webfonts/fa-solid-900.woff2" | relURL }}" as="font" type="font/woff2" crossorigin="anonymous">
   <link rel="preload" href="{{ "lib/JetBrainsMono/web/woff2/JetBrainsMono-Regular.woff2" | relURL }}" as="font" type="font/woff2" crossorigin="anonymous">
-  {{ if eq .Site.Params.Comments.enabled true }}
+  {{- if (and ($enable_comments) (eq .Site.Params.Comments.Engine "cactus_comments")) }}
   <script type="text/javascript" src="https://latest.cactus.chat/cactus.js"></script>
   <link rel="stylesheet" href="https://latest.cactus.chat/style.css" type="text/css">
-  {{ end }}
+  {{- end }}
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>{{ if .IsPage }} {{ .Title }} | {{ end }}{{ .Site.Title }}</title>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -54,7 +54,7 @@
   {{ end }}
   {{ if .Site.GoogleAnalytics }}
   {{ if .Site.Params.googleAnalyticsAsync }}
-    {{ template "_internal/google_analytics_async.html" . }}
+    {{ template "_internal/google_analytics.html" . }}
   {{ else }}
     {{ template "_internal/google_analytics.html" . }}
   {{ end }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -59,15 +59,17 @@
       </div>
     </header>
 
-  {{ with .Resources.ByType "image" }}
+    {{ if (or (not (isset .Site.Params "disable_gallery")) (not .Site.Params.disable_gallery)) -}}
+    {{ with .Resources.ByType "image" -}}
     <div class="article-gallery">
       {{ range $index, $value := . }}
       <a class="gallery-item" href="{{ .RelPermalink }}" rel="gallery_{{ $index }}">
-          <img src="{{ .RelPermalink }}" itemprop="image" />
+        <img src="{{ .RelPermalink }}" itemprop="image" />
       </a>
       {{ end }}
     </div>
-  {{ end }}
+    {{ end }}
+    {{- end }}
     {{ if .Site.Params.tocInline }}
     <div id="toc">
       {{ .TableOfContents }}


### PR DESCRIPTION
sorry for packing this all in one pr, i thought i'd just try. i added a bunch of stuff and updated the docs.

in detail, roughly sorted by impact:

- add matomo analytics integration
- added remark42 comments engine (unfortunately dependent on the cactus comments "fix")
- fixed that the cactus comments script is not included/loaded if cactus comments are not enabled
- add a switch for disabling the page gallery (which is _really_ annoying if you want to include images)
- add an option for an \<hr\> element before comments

_should_ all be tested, at least it works on my site :) .