### PR TITLE
Fixed navigation disappearing issue in chrome version 100.*

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -59,7 +59,7 @@ $(document).ready(function() {
         var topDistance = menu.offset().top;
 
         // hide only the navigation links on desktop
-        if (!nav.is(":visible") && topDistance < 50) {
+        if (!nav.is(":visible") && topDistance < 88) {
           nav.show();
         } else if (nav.is(":visible") && topDistance > 100) {
           nav.hide();
@@ -67,7 +67,7 @@ $(document).ready(function() {
 
         // on tablet, hide the navigation icon as well and show a "scroll to top
         // icon" instead
-        if ( ! $( "#menu-icon" ).is(":visible") && topDistance < 50 ) {
+        if ( ! $( "#menu-icon" ).is(":visible") && topDistance < 88 ) {
           $("#menu-icon-tablet").show();
           $("#top-icon-tablet").hide();
         } else if (! $( "#menu-icon" ).is(":visible") && topDistance > 100) {


### PR DESCRIPTION
OS：macOS Monterey 12.3;

Chrome version:100.0.4896.60 (x86_64);

issue:When I scroll back to the top, the navigation doesn't load.I found that when the span#nav attribute was display: none, the $('#menu').offset().top value immediately exceeded 50.

solution:Modify the judgment range of topDistance not less than 87.