### PR TITLE
Optionally display post images as a gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ weight = 4
 
 Projects section will not be shown if no data file is detected. See [Projects list](#projects-list) below.
 
+### Posts
+
+You can display the images in the page bundle as a gallery at the top of your post:
+
+```yaml
+show_gallery: true
+```
+
 ### Projects list
 
 Create your projects data file `data/projects.yaml|toml|json`. Hugo support yaml, toml and json formats.

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -58,16 +58,17 @@
         {{ end }}
       </div>
     </header>
-
-  {{ with .Resources.ByType "image" }}
-    <div class="article-gallery">
-      {{ range $index, $value := . }}
-      <a class="gallery-item" href="{{ .RelPermalink }}" rel="gallery_{{ $index }}">
-          <img src="{{ .RelPermalink }}" itemprop="image" />
-      </a>
-      {{ end }}
-    </div>
-  {{ end }}
+  {{ if isset .Params.show_gallery }}
+    {{ with .Resources.ByType "image" }}
+      <div class="article-gallery">
+        {{ range $index, $value := . }}
+        <a class="gallery-item" href="{{ .RelPermalink }}" rel="gallery_{{ $index }}">
+            <img src="{{ .RelPermalink }}" itemprop="image" />
+        </a>
+        {{ end }}
+      </div>
+    {{ end }}
+    {{ end }}
     {{ if .Site.Params.tocInline }}
     <div id="toc">
       {{ .TableOfContents }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -58,7 +58,7 @@
         {{ end }}
       </div>
     </header>
-  {{ if isset .Params.show_gallery }}
+  {{ if isset .Params "show_gallery" }}
     {{ with .Resources.ByType "image" }}
       <div class="article-gallery">
         {{ range $index, $value := . }}


### PR DESCRIPTION
I wanted to be able to optionally display the image gallery for images in a post page bundle, so I've added a simple `if` statement around the gallery, with instructions to add `show_gallery: true` to the front matter if you want it enabled.