### PR TITLE
Add the css color-scheme property

### DIFF
--- a/assets/scss/colors/classic.scss
+++ b/assets/scss/colors/classic.scss
@@ -11,3 +11,4 @@ $color-accent-1: #cc2a41;
 $color-accent-2: rgba(86, 124, 119, .8);
 $color-accent-3: #666;
 $color-quote: #cc2a41;
+$css-color-scheme: light;

--- a/assets/scss/colors/dark.scss
+++ b/assets/scss/colors/dark.scss
@@ -11,3 +11,4 @@ $color-accent-3: #cccccc;
 $color-accent-2: #eeeeee;
 $color-accent-1: #2bbc8a;
 $color-quote: #ccffb6;
+$css-color-scheme: dark;

--- a/assets/scss/colors/light.scss
+++ b/assets/scss/colors/light.scss
@@ -12,3 +12,4 @@ $color-accent-3: #666666;
 $color-accent-2: #111111;
 $color-accent-1: #d44375;
 $color-quote: #ab2251;
+$css-color-scheme: light;

--- a/assets/scss/colors/white.scss
+++ b/assets/scss/colors/white.scss
@@ -12,3 +12,4 @@ $color-accent-3: #8c8c8c;
 $color-accent-2: #383838;
 $color-accent-1: #2bbc8a;
 $color-quote: #2bbc8a;
+$css-color-scheme: light;

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -19,6 +19,7 @@ html {
   border-top: 2px solid $color-text;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
+  color-scheme: $css-color-scheme;
 }
 body {
   margin: 0;


### PR DESCRIPTION
The css color-scheme property determines what color scheme the browser uses for example for the scroll bars. This makes sure the dark theme doesn't have a weird jarring light scroll bar that makes it hard to see the position and feels off.