### PR TITLE
Fix DisqusShortname deprecation error in Hugo newer than v0.120.0

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -3,7 +3,7 @@ languageCode = "en-us"
 title = "Cactus theme example"
 theme = "cactus"
 copyright = "You" # cactus will use title if copyright is not set
-disqusShortname = "example" # Used when comments is enabled. Cactus will use site title if not set
+# disqusShortname = "example" # Used when comments is enabled. Cactus will use site title if not set
 # googleAnalytics = "UA-1234-5"
 
 
@@ -45,6 +45,10 @@ weight = 4
     noClasses = true
     style = "dracula"
     tabWidth = 4
+
+[services]
+  [services.disqus]
+    shortname = "example"
 
 [params]
 

--- a/layouts/partials/comments/disqus.html
+++ b/layouts/partials/comments/disqus.html
@@ -7,7 +7,7 @@
       //     return;
     
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      var disqus_shortname = '{{ if .Site.DisqusShortname }}{{ .Site.DisqusShortname }}{{ else }}{{ .Site.Title }}{{ end }}';
+      var disqus_shortname = '{{ if .Site.Config.Services.Disqus.Shortname }}{{ .Site.Config.Services.Disqus.Shortname }}{{ else }}{{ .Site.Title }}{{ end }}';
       dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();


### PR DESCRIPTION
Issue Description: While deploying with Hugo v0.133.1, I encountered the following deprecation error:

ERROR deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.134.0. Use .Site.Config.Services.Disqus.Shortname instead.

Modifications Made: update exampleSite/config.toml with .Site.Config.Services.Disqus.Shortname. This change will help users prevent the same issue from occurring in newer Hugo versions.

```
[services]
  [services.disqus]
    shortname = "example"
```