### PR TITLE
Theme update for Hugo v0.145.0

### DIFF
--- a/assets/scss/colors/voytex.scss
+++ b/assets/scss/colors/voytex.scss
@@ -1,0 +1,13 @@
+$color-background: #1d1f21;
+$color-footer-mobile-1: lighten($color-background, 2%);
+$color-footer-mobile-2: lighten($color-background, 10%);
+$color-background-code: lighten($color-background, 2%);
+$color-border: #666;
+$color-meta: #666;
+$color-meta-code: #666;
+$color-link: rgba(30, 150, 252, 1);
+$color-text: #c9cacc;
+$color-accent-3: #cccccc;
+$color-accent-2: #F1ECCE;
+$color-accent-1: #F18F01;
+$color-quote: #CFFFB3;

--- a/assets/scss/colors/voytex.scss
+++ b/assets/scss/colors/voytex.scss
@@ -5,9 +5,53 @@ $color-background-code: lighten($color-background, 2%);
 $color-border: #666;
 $color-meta: #666;
 $color-meta-code: #666;
-$color-link: rgba(30, 150, 252, 1);
+$color-link: rgba(123, 158, 135, 1);
 $color-text: #c9cacc;
 $color-accent-3: #cccccc;
 $color-accent-2: #F1ECCE;
-$color-accent-1: #F18F01;
+$color-accent-1: rgb(248, 211, 91);
 $color-quote: #CFFFB3;
+
+/*
+/* CSS HEX 
+--naples-yellow: #f8d35bff;
+--raisin-black: #262322ff;
+--cambridge-blue: #7b9e87ff;
+--tangelo: #f6511dff;
+
+/* CSS HSL 
+--naples-yellow: hsla(46, 92%, 66%, 1);
+--raisin-black: hsla(15, 6%, 14%, 1);
+--cambridge-blue: hsla(141, 15%, 55%, 1);
+--tangelo: hsla(14, 92%, 54%, 1);
+
+/* SCSS HEX 
+$naples-yellow: #f8d35bff;
+$raisin-black: #262322ff;
+$cambridge-blue: #7b9e87ff;
+$tangelo: #f6511dff;
+
+/* SCSS HSL *
+$naples-yellow: hsla(46, 92%, 66%, 1);
+$raisin-black: hsla(15, 6%, 14%, 1);
+$cambridge-blue: hsla(141, 15%, 55%, 1);
+$tangelo: hsla(14, 92%, 54%, 1);
+
+/* SCSS RGB 
+$naples-yellow: rgba(248, 211, 91, 1);
+$raisin-black: rgba(38, 35, 34, 1);
+$cambridge-blue: rgba(123, 158, 135, 1);
+$tangelo: rgba(246, 81, 29, 1);
+
+/* SCSS Gradient 
+$gradient-top: linear-gradient(0deg, #f8d35bff, #262322ff, #7b9e87ff, #f6511dff);
+$gradient-right: linear-gradient(90deg, #f8d35bff, #262322ff, #7b9e87ff, #f6511dff);
+$gradient-bottom: linear-gradient(180deg, #f8d35bff, #262322ff, #7b9e87ff, #f6511dff);
+$gradient-left: linear-gradient(270deg, #f8d35bff, #262322ff, #7b9e87ff, #f6511dff);
+$gradient-top-right: linear-gradient(45deg, #f8d35bff, #262322ff, #7b9e87ff, #f6511dff);
+$gradient-bottom-right: linear-gradient(135deg, #f8d35bff, #262322ff, #7b9e87ff, #f6511dff);
+$gradient-top-left: linear-gradient(225deg, #f8d35bff, #262322ff, #7b9e87ff, #f6511dff);
+$gradient-bottom-left: linear-gradient(315deg, #f8d35bff, #262322ff, #7b9e87ff, #f6511dff);
+$gradient-radial: radial-gradient(#f8d35bff, #262322ff, #7b9e87ff, #f6511dff);
+
+*/

--- a/assets/scss/partial/index.scss
+++ b/assets/scss/partial/index.scss
@@ -17,6 +17,7 @@
     margin-bottom: 1rem;
     margin-left: 0;
     list-style-type: none;
+    display: block;
 
     .meta {
       display: block;
@@ -32,13 +33,32 @@
     .post-item {
       display: flex;
       margin-bottom: 5px;
+      flex-direction: column;
 
       .meta {
         text-align: left;
       }
+
+      .post-thumbnail {
+        margin-bottom: 1rem;
+      }
     }
   }
 }
+
+@media (max-width: 480px) {
+  .post-list {
+    .post-item {
+      display: flex;
+      flex-direction: column;
+
+      .post-thumbnail {
+        margin-bottom: 1rem;
+      }
+    }
+  }
+}
+
 .project-list {
   padding: 0;
   list-style: none;

--- a/assets/scss/partial/index.scss
+++ b/assets/scss/partial/index.scss
@@ -1,6 +1,18 @@
 .post-list {
   padding: 0;
 
+  .post-thumbnail {
+    display: inline-block;
+    float: left;
+    margin-right: 20px;
+    margin-bottom: 10px;
+    min-width: 200px;
+    height: 100px;
+    border-radius: 5px;
+    background-repeat: no-repeat;
+    object-fit: cover;
+  }
+
   .post-item {
     margin-bottom: 1rem;
     margin-left: 0;

--- a/layouts/_default/list-w-thumbs.html
+++ b/layouts/_default/list-w-thumbs.html
@@ -1,0 +1,30 @@
+{{ define "main"}}
+<div id="archive">
+  <ul class="post-list">
+
+  {{ $pages := .Paginator.Pages }}
+  {{ if .Site.Params.showAllPostsArchive }}
+    {{ $pages = .Pages }}
+  {{ end }}
+
+  {{ range (sort $pages "Date" "desc") }}
+    {{ $pageYear := (.Date.Format "2006") }}
+    {{ if (ne $pageYear ($.Scratch.Get "year")) }}
+    {{ $.Scratch.Set "year" $pageYear }}
+    <h2>{{ $pageYear }}</h2>
+    {{ end }}
+    <li class="post-item">
+      <div>
+        <img src="{{ .Site.BaseURL }}{{ .Params.thumbnail }}" alt="{{ .Title }}" class="post-thumbnail" id="logo">
+        <span>    
+          <a class="" href="{{ .Permalink }}">{{ if .Title }} {{ .Title }} {{ else }} Untitled {{ end }}</a>
+        </span>
+      </div>
+    </li>
+    {{ end }}
+  </ul>
+  {{ if eq .Site.Params.showAllPostsArchive false }}
+    {{ partial "pagination.html" . }}
+  {{ end }}
+</div>
+{{ end }}

--- a/layouts/_default/list-w-thumbs.html
+++ b/layouts/_default/list-w-thumbs.html
@@ -8,11 +8,11 @@
   {{ end }}
 
   {{ range (sort $pages "Date" "desc") }}
-    {{ $pageYear := (.Date.Format "2006") }}
+    {{/*  {{ $pageYear := (.Date.Format "2006") }}
     {{ if (ne $pageYear ($.Scratch.Get "year")) }}
     {{ $.Scratch.Set "year" $pageYear }}
     <h2>{{ $pageYear }}</h2>
-    {{ end }}
+    {{ end }}  */}}
     <li class="post-item">
       <div>
         <img src="{{ .Site.BaseURL }}{{ .Params.thumbnail }}" alt="{{ .Title }}" class="post-thumbnail" id="logo">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -14,8 +14,9 @@
     <h2>{{ $pageYear }}</h2>
     {{ end }}
     <li class="post-item">
+      <img src="{{ .Site.BaseURL }}{{ .Params.thumbnail }}" alt="{{ .Title }}" class="post-thumbnail" id="logo">
       <div class="meta">
-        <time datetime="{{ time .Date }}" itemprop="datePublished">{{ .Date.Format (.Site.Params.dateFormat | default "2006-01-02") }}</time>
+        {{/*  <time datetime="{{ time .Date }}" itemprop="datePublished">{{ .Date.Format (.Site.Params.dateFormat | default "2006-01-02") }}</time>  */}}
       </div>
       <span>    
         <a class="" href="{{ .Permalink }}">{{ if .Title }} {{ .Title }} {{ else }} Untitled {{ end }}</a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -33,7 +33,7 @@
   {{ partial "optional-about.html" . }}
   </section>
 
-  <section id="writing">
+  {{/*  <section id="writing">
     <span class="h1"><a href="{{ .Site.Params.mainSection | absURL }}">{{ .Site.Params.mainSectionTitle | default "Writings" }}</a></span>
     {{ if (and (and (isset .Site.Params "tagsoverview") (eq .Site.Params.tagsOverview true)) (gt (len .Site.Taxonomies.tags) 0)) }}
     <span class="h2">Topics</span>
@@ -80,7 +80,7 @@
       {{ end }}
     </ul>
     {{ end }}
-  </section>
+  </section>  */}}
 
   {{ $showProjectsList := false }}
   {{ if (isset .Site.Params "showprojectslist") }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,7 +4,7 @@
     {{ .Site.Params.description | $.Page.RenderString }}
   {{ end }}
   {{ if isset .Site.Params "social" }}
-      <p>Find me on
+      <p>
       {{ $length := (len .Site.Params.social) }}
       {{ range $index, $elem := .Site.Params.social}}
       {{ if eq $elem.name "email" }}
@@ -24,12 +24,8 @@
           <i class="fab fa-{{ lower $elem.name }}" aria-hidden="true"></i>
         </a>
         {{ end }}
-        {{ if (lt (add $index 2) $length) }}
-          {{- print " , " -}}
-        {{ else if (lt (add $index 1) $length) }}
-          {{- print " and " -}}
-        {{ else }}
-          {{- print "." -}}
+        {{ if (lt (add $index 1) $length) }}
+          {{- print " / " -}}
         {{ end }}
       {{ end }}
       </p>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,8 +5,8 @@
   <div class="footer-right">
     <nav>
       <ul>
-        {{ range .Site.Menus.main }} 
-        <li><a href="{{ .URL }}">{{ .Name }}</a></li>
+        {{ range $.Site.Home.AllTranslations }}
+          <li><a href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a> </li>
         {{ end }}
       </ul>
     </nav>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,11 +4,15 @@
   </div>
   <div class="footer-right">
     <nav>
+      {{ if .IsTranslated }}
       <ul>
-        {{ range $.Site.Home.AllTranslations }}
-          <li><a href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a> </li>
+        {{ range .Translations }}
+        <li>
+          <a href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+        </li>
         {{ end }}
       </ul>
+      {{ end }}
     </nav>
   </div>
 </footer>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -24,7 +24,7 @@
   {{ $colortheme := .Scratch.Get "colortheme" }}
 
   {{- $options := (dict "targetPath" "css/styles.css" "outputStyle" "compressed" "enableSourceMap" "true") -}}
-  {{- $styles := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "scss/style.scss" . | resources.ToCSS $options | resources.Fingerprint "sha512" }}
+  {{- $styles := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "scss/style.scss" . | css.Sass $options | resources.Fingerprint "sha512" }}
   <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}"> 
 
   <!-- Custom CSS -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -42,11 +42,7 @@
     {{ printf `<link href="%s" rel="%s" type="%s" title="%s" />` .Permalink .Rel .MediaType.Type $.Site.Title | safeHTML }}
   {{ end }}
   {{ end }}
-  {{ if .Site.GoogleAnalytics }}
-  {{ if .Site.Params.googleAnalyticsAsync }}
-    {{ template "_internal/google_analytics_async.html" . }}
-  {{ else }}
+  {{ if .Site.Config.Services.GoogleAnalytics.ID }}
     {{ template "_internal/google_analytics.html" . }}
-  {{ end }}
   {{ end }}
 </head>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,7 +6,7 @@
     <div id="logo" style="background-image: url({{ .Site.Params.logo | absURL }})"></div>
   {{ else }}
     <div id="logo" style="background-image: url({{ "images/logo.png" | absURL }})"></div>
-  {{ end}}
+  {{ end }}
   <div id="title">
     <h1>{{ .Site.Title }}</h1>
   </div>


### PR DESCRIPTION
# General
Theme was not able to build under `hugo v0.145.0` due to:
- #141, #144 
- `resources.ToCSS` was deprecated

This PR solves both.