### PR TITLE
Theme update for Hugo v0.145.0

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -24,7 +24,7 @@
   {{ $colortheme := .Scratch.Get "colortheme" }}
 
   {{- $options := (dict "targetPath" "css/styles.css" "outputStyle" "compressed" "enableSourceMap" "true") -}}
-  {{- $styles := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "scss/style.scss" . | resources.ToCSS $options | resources.Fingerprint "sha512" }}
+  {{- $styles := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "scss/style.scss" . | css.Sass $options | resources.Fingerprint "sha512" }}
   <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}"> 
 
   <!-- Custom CSS -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -42,11 +42,7 @@
     {{ printf `<link href="%s" rel="%s" type="%s" title="%s" />` .Permalink .Rel .MediaType.Type $.Site.Title | safeHTML }}
   {{ end }}
   {{ end }}
-  {{ if .Site.GoogleAnalytics }}
-  {{ if .Site.Params.googleAnalyticsAsync }}
-    {{ template "_internal/google_analytics_async.html" . }}
-  {{ else }}
+  {{ if .Site.Config.Services.GoogleAnalytics.ID }}
     {{ template "_internal/google_analytics.html" . }}
-  {{ end }}
   {{ end }}
 </head>


### PR DESCRIPTION
# General
Theme was not able to build under `hugo v0.145.0` due to:
- #141, #144 
- `resources.ToCSS` was deprecated

This PR solves both.